### PR TITLE
[FIX] Change request type recognition

### DIFF
--- a/lib/engine/RequestDefinition.js
+++ b/lib/engine/RequestDefinition.js
@@ -468,15 +468,15 @@ class RequestDefinition {
    * @memberof RequestDefinition
    */
   calculatePath() {
-    if (this._resource.entityTypeModel.hasStream) {
-      this._path = `/${this._resource.getListResourcePath()}/\$value`;
-    } else if (this._isList) {
+    if (this._isList) {
       let urlQuery = this._resource.urlQuery({
         $top: 100,
         $skip: 0,
         $format: "json",
       });
       this._path = `/${this._resource.getListResourcePath()}?${urlQuery}`;
+    } else if (this._resource.entityTypeModel.hasStream) {
+      this._path = `/${this._resource.getListResourcePath()}/\$value`;
     } else {
       let urlQuery = this._resource.urlQuery({
         $format: "json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sap_oss/odata-library",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "OData client for testing Netweawer OData services.",
   "main": "index.js",
   "dependencies": {

--- a/test/unit/engine/RequestDefinition.js
+++ b/test/unit/engine/RequestDefinition.js
@@ -207,6 +207,9 @@ describe("RequestDefinition", function () {
 
   describe(".calculatePath()", function () {
     it("stream path", function () {
+      sinon.stub(request, "_isList").get(function () {
+        return false;
+      });
       request._resource.entityTypeModel.hasStream = true;
       request.calculatePath();
       assert.strictEqual(request._path, "/path/$value");
@@ -215,6 +218,7 @@ describe("RequestDefinition", function () {
       sinon.stub(request, "_isList").get(function () {
         return true;
       });
+      request._resource.entityTypeModel.hasStream = true;
       sinon.stub(request._resource, "urlQuery").returns("QUERY");
       request.calculatePath();
       assert.strictEqual(request._path, "/path?QUERY");


### PR DESCRIPTION
The GET requests automatically recognize
type of request (list or entity or stream).
The patch change priority of checks. List
has greatest priority now.

Topic: #2