### PR TITLE
Read content for services without CSRF token support

### DIFF
--- a/lib/agent/Agent.js
+++ b/lib/agent/Agent.js
@@ -438,11 +438,17 @@ class Agent {
           let promise = this.sendRequest(
             "POST",
             "/$batch",
-            {
-              "x-csrf-token": csrfToken,
-              "Content-Type": `multipart/mixed;boundary=${batchNormalized.boundary()}`,
-              Accept: "multipart/mixed",
-            },
+            _.assign(
+              {
+                "Content-Type": `multipart/mixed;boundary=${batchNormalized.boundary()}`,
+                Accept: "multipart/mixed",
+              },
+              csrfToken
+                ? {
+                    "x-csrf-token": csrfToken,
+                  }
+                : {}
+            ),
             payload,
             true
           );
@@ -717,8 +723,18 @@ class Agent {
     return normalizedBatchResponse;
   }
 
-  getResultPath(isList) {
-    return isList ? this._listResultPath : this._instanceResultPath;
+  /**
+   * Determine path to result content
+   *
+   * @param {Boolean} isList true if result is array
+   * @param {IncomingMessage} result object with response from backend
+   *
+   * @return {String} path with dot notation to content of response
+   */
+  getResultPath(isList, result) {
+    return isList && _.has(result, this._listResultPath)
+      ? this._listResultPath
+      : this._instanceResultPath;
   }
 
   setServiceVersion(version) {

--- a/lib/agent/batch/Request.js
+++ b/lib/agent/batch/Request.js
@@ -86,10 +86,12 @@ class Request {
         _.map(
           _.assign(
             body.length > 0
-              ? {
-                  "x-csrf-token": `${csrfToken}`,
-                  "Content-Length": _.get(body, 0).length,
-                }
+              ? _.assign(
+                  {
+                    "Content-Length": _.get(body, 0).length,
+                  },
+                  csrfToken ? { "x-csrf-token": `${csrfToken}` } : {}
+                )
               : {},
             this.headers
           ),

--- a/lib/engine/FunctionImport.js
+++ b/lib/engine/FunctionImport.js
@@ -119,7 +119,9 @@ class FunctionImport extends Resource {
       this.agent
         .fetchToken()
         .then((csrfToken) => {
-          this.header("x-csrf-token", csrfToken);
+          if (csrfToken) {
+            this.header("x-csrf-token", csrfToken);
+          }
           this.header("Content-type", "application/json");
           this.header("Accept", "application/json");
 

--- a/lib/engine/QueryableResource.js
+++ b/lib/engine/QueryableResource.js
@@ -610,7 +610,9 @@ class QueryableResource extends Resource {
   determineRequestHeaders(request, token) {
     let hasStream = request._resource.entityTypeModel.hasStream;
 
-    request.header("x-csrf-token", token);
+    if (token) {
+      request.header("x-csrf-token", token);
+    }
     if (!hasStream) {
       request.header("Accept", "application/json");
     }
@@ -637,7 +639,7 @@ class QueryableResource extends Resource {
     } else if (hasStream) {
       value = response.body;
     } else {
-      resultPath = this.agent.getResultPath(request._isList);
+      resultPath = this.agent.getResultPath(request._isList, response);
       value = this._unwrapNestedProperties(
         _.get(response, resultPath, response.ok)
       );

--- a/lib/engine/RequestDefinition.js
+++ b/lib/engine/RequestDefinition.js
@@ -499,8 +499,7 @@ class RequestDefinition {
   get _isList() {
     // Navigation property: If the multiplicity is 1..1 then no key is required and there will always be a single entity result
     let isNavPropSingle =
-      this._resource.hasOwnProperty("isMultiple") &&
-      !this._resource.isMultiple();
+      _.isFunction(this._resource.isMultiple) && !this._resource.isMultiple();
     let isEntity =
       _.has(this, "_keyValue") || _.has(this, "_payload") || isNavPropSingle;
     return this._resource.isParameterized || !isEntity;

--- a/test/unit/agent/batch/Request.js
+++ b/test/unit/agent/batch/Request.js
@@ -86,7 +86,33 @@ describe("agent/batch/Batch", function () {
           "Content-Type: application/http",
           "Content-Transfer-Encoding: binary\n",
           "POST path/to/resource HTTP/1.1",
+          "Content-Length: 4",
           "x-csrf-token: X-CSRF-TOKEN",
+          "Header1: header-value1",
+          "Header2: header-value2",
+          "",
+          "BODY",
+        ].join("\n")
+      );
+    });
+
+    it("Payload for requests with body but without csrf token", function () {
+      request = new Request(
+        "POST",
+        "path/to/resource",
+        {
+          Header1: "header-value1",
+          Header2: "header-value2",
+        },
+        "BODY"
+      );
+      sinon.stub(request, "body").returns(["BODY"]);
+      assert.equal(
+        request.payload(),
+        [
+          "Content-Type: application/http",
+          "Content-Transfer-Encoding: binary\n",
+          "POST path/to/resource HTTP/1.1",
           "Content-Length: 4",
           "Header1: header-value1",
           "Header2: header-value2",

--- a/test/unit/engine/FunctionImport.js
+++ b/test/unit/engine/FunctionImport.js
@@ -308,6 +308,43 @@ describe("FunctionImport", function () {
         );
       });
     });
+    it("Success send request and receive response content without csrf token", function () {
+      innerAgent.fetchToken = sinon.stub().returns(Promise.resolve(null));
+      innerAgent.post = sinon.stub().returns(
+        Promise.resolve({
+          body: {
+            d: "RESPONSE_CONTENT",
+          },
+        })
+      );
+      functionImport.defaultRequest._headers = "HEADERS";
+      functionImport.meta.name = "FUNCTION_IMPORT_NAME";
+
+      return functionImport.post().then((res) => {
+        assert.equal(res, "RESPONSE_CONTENT");
+        assert.ok(
+          functionImport.header
+            .getCall(0)
+            .calledWith("Content-type", "application/json")
+        );
+        assert.ok(
+          functionImport.header
+            .getCall(1)
+            .calledWith("Accept", "application/json")
+        );
+        assert.ok(functionImport.header.calledTwice);
+        assert.ok(functionImport.reset.called);
+        assert.ok(
+          innerAgent.post.calledWith(
+            "/FUNCTION_IMPORT_NAME?QUERY",
+            "HEADERS",
+            undefined,
+            "DEFAULT_BATCH",
+            "DEFAULT_CHANGESET"
+          )
+        );
+      });
+    });
   });
 
   describe(".get()", function () {

--- a/test/unit/engine/QueryableResource.js
+++ b/test/unit/engine/QueryableResource.js
@@ -1607,6 +1607,17 @@ describe("QueryableResource", function () {
         header: sinon.stub(),
       };
     });
+
+    it("Headers without csrf token", function () {
+      request._resource.entityTypeModel.hasStream = false;
+      entitySet.determineRequestHeaders(request, null);
+      assert.ok(request.header.calledOnce);
+      assert.deepEqual(request.header.getCall(0).args, [
+        "Accept",
+        "application/json",
+      ]);
+    });
+
     it("Headers for standard OData request", function () {
       request._resource.entityTypeModel.hasStream = false;
       entitySet.determineRequestHeaders(request, "TOKEN");
@@ -1672,7 +1683,9 @@ describe("QueryableResource", function () {
         entitySet.determineResponseResult(request, response),
         "RESULT"
       );
-      assert.ok(innerAgent.getResultPath.calledWithExactly("IS_LIST"));
+      assert.ok(
+        innerAgent.getResultPath.calledWithExactly("IS_LIST", response)
+      );
       assert.ok(entitySet._unwrapNestedProperties.calledWithExactly("BODY"));
     });
   });

--- a/test/unit/engine/RequestDefinition.js
+++ b/test/unit/engine/RequestDefinition.js
@@ -247,6 +247,10 @@ describe("RequestDefinition", function () {
   });
 
   describe("._isList", function () {
+    it("request definition for invalid single navigation property definition", function () {
+      request._resource.isMultiple = true;
+      assert.strictEqual(request._isList, true);
+    });
     it("request definition for single navigation property", function () {
       request._resource.isMultiple = sinon.stub().returns(false);
       assert.strictEqual(request._isList, false);


### PR DESCRIPTION
Some services does not support CSRF token handling. The patch enables usage of the services by odata-library.
