### PR TITLE
Read stream by single entity

### DIFF
--- a/doc/GET_ENTITY_SET.md
+++ b/doc/GET_ENTITY_SET.md
@@ -230,6 +230,11 @@ The navigation property which provide binary data has to be marked as *HasStream
 in metadata. Response is `Buffer`which contains received binary data.
 
 
+### Read stream by navigation property
+
+Common use of navigation property with relation 1:1 is producing
+stream.
+
 ```javascript
     service.Items.key({
             ApplObjectType: "PARAGON",
@@ -239,5 +244,30 @@ in metadata. Response is `Buffer`which contains received binary data.
     })
     .then((dataBuffer) => {
         parsePdf(dataBuffer);
+    });
+```
+
+### Read stream from by single entity
+
+Read stream entity with entity definiton. The example
+
+
+```javascript
+service.C_AllocationCycleTP.filter("IsActiveEntity eq true")
+    .top(1)
+    .get()
+    .then((result) => {
+     return service.AllocExcelTemplateSet.key({
+	     cycle: [
+	    	 result[0].AllocationType,
+	    	 result[0].AllocationCycle,
+	    	 new Date(parseInt(result[0].AllocationCycleStartDate.match(/\/Date\((\d+)\)\//)[1], 10))
+	    		 .toISOString()
+	    		 .replace(/(-|T.*)/g, "")
+	     ].join(",")
+     }).get();
+    })
+    .then((result) => {
+         assert.ok(result instanceof Buffer);
     });
 ```

--- a/lib/engine/RequestDefinition.js
+++ b/lib/engine/RequestDefinition.js
@@ -478,6 +478,8 @@ class RequestDefinition {
         $format: "json",
       });
       this._path = `/${this._resource.getListResourcePath()}?${urlQuery}`;
+    } else if (this._resource.entityTypeModel.hasStream && this._isEntity) {
+      this._path = `/${this._resource.getSingleResourcePath()}/\$value`;
     } else if (this._resource.entityTypeModel.hasStream) {
       this._path = `/${this._resource.getListResourcePath()}/\$value`;
     } else {
@@ -497,12 +499,16 @@ class RequestDefinition {
    * @memberof RequestDefinition
    */
   get _isList() {
+    return this._resource.isParameterized || !this._isEntity;
+  }
+
+  get _isEntity() {
     // Navigation property: If the multiplicity is 1..1 then no key is required and there will always be a single entity result
     let isNavPropSingle =
       _.isFunction(this._resource.isMultiple) && !this._resource.isMultiple();
-    let isEntity =
-      _.has(this, "_keyValue") || _.has(this, "_payload") || isNavPropSingle;
-    return this._resource.isParameterized || !isEntity;
+    return (
+      _.has(this, "_keyValue") || _.has(this, "_payload") || isNavPropSingle
+    );
   }
 
   /**

--- a/test/unit/engine/RequestDefinition.js
+++ b/test/unit/engine/RequestDefinition.js
@@ -219,7 +219,21 @@ describe("RequestDefinition", function () {
   });
 
   describe(".calculatePath()", function () {
-    it("stream path", function () {
+    it("entity stream path", function () {
+      sinon.stub(request, "_isList").get(function () {
+        return false;
+      });
+      sinon.stub(request, "_isEntity").get(function () {
+        return true;
+      });
+      request._resource.getSingleResourcePath = sinon
+        .stub()
+        .returns("SINGLE_PATH");
+      request._resource.entityTypeModel.hasStream = true;
+      request.calculatePath();
+      assert.strictEqual(request._path, "/SINGLE_PATH/$value");
+    });
+    it("list stream path", function () {
       sinon.stub(request, "_isList").get(function () {
         return false;
       });
@@ -270,6 +284,28 @@ describe("RequestDefinition", function () {
       request._payload = "PAYLOAD";
       request._resource.isParameterized = true;
       assert.strictEqual(request._isList, true);
+    });
+  });
+
+  describe("_isEntity", function () {
+    it("request definition for invalid single navigation property definition", function () {
+      request._resource.isMultiple = true;
+      assert.strictEqual(request._isEntity, false);
+    });
+    it("request definition for single navigation property", function () {
+      request._resource.isMultiple = sinon.stub().returns(false);
+      assert.strictEqual(request._isEntity, true);
+    });
+    it("request definition for one entity", function () {
+      request._keyValue = "KEY_VALUE";
+      assert.strictEqual(request._isEntity, true);
+    });
+    it("request definition for entity create/update", function () {
+      request._payload = "PAYLOAD";
+      assert.strictEqual(request._isEntity, true);
+    });
+    it("request definition for entity set", function () {
+      assert.strictEqual(request._isEntity, false);
     });
   });
 


### PR DESCRIPTION
Read correctly stream from entity set by definition of single entity.  The previous implementation accepts only 1:1 navigation properties.
