### PR TITLE
[FIX] Return correct context for chaining

### DIFF
--- a/lib/engine/NavigationProperty.js
+++ b/lib/engine/NavigationProperty.js
@@ -97,14 +97,18 @@ class NavigationProperty extends QueryableResource {
   /**
    * Set key definiton for the entity set reading
    *
-   * @return {RequestDefinition} itself for the chaining
+   * @return {NavigationProperty} itself for the chaining
    *
    * @memberof NavigationProperty
    */
   key() {
-    return this.isMultiple()
-      ? super.key.apply(this, arguments)
-      : this.defaultRequest.registerAssociations();
+    if (this.isMultiple()) {
+      super.key.apply(this, arguments);
+    } else {
+      this.defaultRequest.registerAssociations();
+    }
+
+    return this;
   }
 }
 

--- a/lib/engine/QueryableResource.js
+++ b/lib/engine/QueryableResource.js
@@ -38,42 +38,50 @@ class QueryableResource extends Resource {
 
   // see RequestDefinition.top
   top(top) {
-    return this.defaultRequest.top(top);
+    this.defaultRequest.top(top);
+    return this;
   }
 
   // see RequestDefinition.select
   select(...args) {
-    return this.defaultRequest.select(...args);
+    this.defaultRequest.select(...args);
+    return this;
   }
 
   // see RequestDefinition.skip
   skip(skip) {
-    return this.defaultRequest.skip(skip);
+    this.defaultRequest.skip(skip);
+    return this;
   }
 
   // see RequestDefinition.filter
   filter(filter) {
-    return this.defaultRequest.filter(filter);
+    this.defaultRequest.filter(filter);
+    return this;
   }
 
   // see RequestDefinition.orderby
   orderby(...args) {
-    return this.defaultRequest.orderby(...args);
+    this.defaultRequest.orderby(...args);
+    return this;
   }
 
   // see RequestDefinition.expand
   expand(...args) {
-    return this.defaultRequest.expand(...args);
+    this.defaultRequest.expand(...args);
+    return this;
   }
 
   // see RequestDefinition.search
   search(pattern) {
-    return this.defaultRequest.search(pattern);
+    this.defaultRequest.search(pattern);
+    return this;
   }
 
   // see RequestDefinition.key
   key(entityKey) {
-    return this.defaultRequest.key(entityKey);
+    this.defaultRequest.key(entityKey);
+    return this;
   }
 
   /**

--- a/lib/engine/Resource.js
+++ b/lib/engine/Resource.js
@@ -122,12 +122,14 @@ class Resource {
 
   // see RequestDefinition.parameter
   parameter(parameterName, parameterValue) {
-    return this.defaultRequest.parameter(parameterName, parameterValue);
+    this.defaultRequest.parameter(parameterName, parameterValue);
+    return this;
   }
 
   // see RequestDefinition.parameters
   parameters(parameters) {
-    return this.defaultRequest.parameters(parameters);
+    this.defaultRequest.parameters(parameters);
+    return this;
   }
 
   /**
@@ -146,12 +148,13 @@ class Resource {
    * @param {String} key name of the header
    * @param {String} value value of the header
    *
-   * @return {RequestDefinition} itself for the chaining
+   * @return {Resource} itself for the chaining
    *
    * @memberof Resource
    */
   header(key, value) {
-    return this.defaultRequest.header(key, value);
+    this.defaultRequest.header(key, value);
+    return this;
   }
 
   /**
@@ -191,12 +194,13 @@ class Resource {
    * @param {String} name name of the parameter
    * @param {Any} [value] parameter value is optional, if it is
    *
-   * @return {RequestDefinition} himself for the chaining
+   * @return {Resource} itself for the chaining
    *
    * @memberof Resource
    */
   setQueryParameter(name, value) {
-    return this.defaultRequest.setQueryParameter(name, value);
+    this.defaultRequest.setQueryParameter(name, value);
+    return this;
   }
 
   /**
@@ -207,7 +211,7 @@ class Resource {
    * @param {String} name name of the parameter
    * @param {Any} [value] parameter value is optional, if it is
    *
-   * @return {RequestDefinition} itself for the chaining
+   * @return {Resource} itself for the chaining
    *
    * @memberof Resource
    */

--- a/test/unit/engine/NavigationProperty.js
+++ b/test/unit/engine/NavigationProperty.js
@@ -348,6 +348,14 @@ describe("NavigationProperty", function () {
   });
 
   describe(".key()", function () {
+    it("Returns itself for chaining", function () {
+      sinon.stub(navigationProperty, "isMultiple").returns(false);
+      sinon.stub(navigationProperty.defaultRequest, "registerAssociations");
+
+      const reference = navigationProperty.key("PARAMS");
+
+      assert.ok(reference === navigationProperty);
+    });
     it("Is multiple association", function () {
       sinon.stub(navigationProperty, "isMultiple").returns(true);
       sinon.stub(Parent.prototype, "key");

--- a/test/unit/engine/QueryableResource.js
+++ b/test/unit/engine/QueryableResource.js
@@ -81,6 +81,12 @@ describe("QueryableResource", function () {
         entitySet.search(100);
       }, /pattern/);
     });
+    it("Returns itself for chaining", function () {
+      sinon.stub(entitySet.defaultRequest, "setQueryParameter");
+      innerEntitySetModel.sap.searchable = true;
+      const reference = entitySet.search("PATTERN");
+      assert.ok(reference === entitySet);
+    });
     it("Run search on searchable EntitySet with invalid pattern", function () {
       sinon.stub(entitySet.defaultRequest, "setQueryParameter");
       innerEntitySetModel.sap.searchable = true;
@@ -127,7 +133,11 @@ describe("QueryableResource", function () {
         entitySet.select("Blud");
       });
     });
-    it("Pass one property nameso select clause", function () {
+    it("Returns itself for chaining", function () {
+      const reference = entitySet.select("Property_1");
+      assert.ok(reference === entitySet);
+    });
+    it("Pass one property name to select clause", function () {
       entitySet.select("Property_1");
       assert.deepEqual(
         entitySet.defaultRequest.setQueryParameter.getCall(0).args,
@@ -200,6 +210,10 @@ describe("QueryableResource", function () {
         entitySet.expand("unexistingNavProperty");
       });
     });
+    it("Returns itself for chaining", function () {
+      const reference = entitySet.expand("navProperty");
+      assert.ok(reference === entitySet);
+    });
     it("Pass one navigation property name to expand clause", function () {
       entitySet.expand("navProperty");
       assert.deepEqual(
@@ -242,6 +256,12 @@ describe("QueryableResource", function () {
         entitySet.top("BLUD");
       }, /top value/);
     });
+    it("Returns itself for chaining", function () {
+      sinon.stub(entitySet.defaultRequest, "setQueryParameter");
+      innerEntitySetModel.sap.pageable = true;
+      const reference = entitySet.top(100);
+      assert.ok(reference === entitySet);
+    });
     it("Valid top clause set $top parameter", function () {
       sinon.stub(entitySet.defaultRequest, "setQueryParameter");
       innerEntitySetModel.sap.pageable = true;
@@ -271,6 +291,12 @@ describe("QueryableResource", function () {
         entitySet.skip(-1);
       }, /positive/);
     });
+    it("Returns itself for chaining", function () {
+      sinon.stub(entitySet.defaultRequest, "setQueryParameter");
+      innerEntitySetModel.sap.pageable = true;
+      const reference = entitySet.skip(0);
+      assert.ok(reference === entitySet);
+    });
     it("Zero is valid skip parameter.", function () {
       sinon.stub(entitySet.defaultRequest, "setQueryParameter");
       innerEntitySetModel.sap.pageable = true;
@@ -292,6 +318,11 @@ describe("QueryableResource", function () {
   });
 
   describe(".filter()", function () {
+    it("Returns itself for chaining", function () {
+      sinon.stub(entitySet.defaultRequest, "setQueryParameter");
+      const reference = entitySet.filter("FILTER_DEFINITION");
+      assert.ok(reference === entitySet);
+    });
     it("Valid filter clause set $filter parameter", function () {
       sinon.stub(entitySet.defaultRequest, "setQueryParameter");
       entitySet.filter("FILTER_DEFINITION");
@@ -303,6 +334,11 @@ describe("QueryableResource", function () {
   });
 
   describe(".orderby()", function () {
+    it("Returns itself for chaining", function () {
+      sinon.stub(entitySet.defaultRequest, "setQueryParameter");
+      const reference = entitySet.orderby("Property_1", "Property_2 desc");
+      assert.ok(reference === entitySet);
+    });
     it("Valid sort clause set $orderby parameter", function () {
       sinon.stub(entitySet.defaultRequest, "setQueryParameter");
       entitySet.orderby("Property_1", "Property_2 desc");
@@ -314,9 +350,15 @@ describe("QueryableResource", function () {
   });
 
   describe(".key()", function () {
+    it("Returns itself for chaining", function () {
+      sinon.stub(entitySet.defaultRequest, "key");
+      const reference = entitySet.key("A");
+      assert.ok(reference === entitySet);
+    });
     it("Uses request key", function () {
-      sinon.stub(entitySet.defaultRequest, "key").withArgs("A").returns("X");
-      assert.strictEqual(entitySet.key("A"), "X");
+      sinon.stub(entitySet.defaultRequest, "key");
+      entitySet.key("A");
+      assert.ok(entitySet.defaultRequest.key.calledWithExactly("A"));
     });
   });
 
@@ -895,6 +937,10 @@ describe("QueryableResource", function () {
   });
 
   describe(".raw()", function () {
+    it("Returns itself for chaining", function () {
+      const reference = entitySet.raw();
+      assert.ok(reference === entitySet);
+    });
     it("Enable raw response", function () {
       let parameters = entitySet.defaultRequest;
       assert.strictEqual(parameters._isRaw, false);

--- a/test/unit/engine/Resource.js
+++ b/test/unit/engine/Resource.js
@@ -143,6 +143,12 @@ describe("Resource", function () {
   });
 
   describe(".parameters()", function () {
+    it("Returns itself for chaining", function () {
+      let request = resource.defaultRequest;
+      sinon.stub(request, "parameters");
+      const reference = resource.parameters({});
+      assert.ok(reference === resource);
+    });
     it("sets parameters", function () {
       let request = resource.defaultRequest;
       sinon.stub(request, "parameters");
@@ -162,6 +168,10 @@ describe("Resource", function () {
   });
 
   describe(".setQueryParameter()", function () {
+    it("Returns itself for chaining", function () {
+      const reference = resource.setQueryParameter("ARG1", "VAL1");
+      assert.ok(reference === resource);
+    });
     it("Set different types of values", function () {
       resource.setQueryParameter("$top", 100);
       assert.strictEqual(resource.getQueryParameter("$top"), 100);
@@ -180,13 +190,15 @@ describe("Resource", function () {
   });
 
   describe(".queryParameter()", function () {
+    it("Returns itself for chaining", function () {
+      const reference = resource.queryParameter("ARG1", "VAL1");
+      assert.ok(reference === resource);
+    });
     it("Pass all parameters to the setQueryParameter method", function () {
-      sinon.stub(resource, "setQueryParameter");
-      resource.queryParameter("ARG1", "ARG2");
-      assert.deepEqual(resource.setQueryParameter.getCall(0).args, [
-        "ARG1",
-        "ARG2",
-      ]);
+      resource.queryParameter("ARG1", "VAL1").queryParameter("ARG2", "VAL2");
+
+      assert.strictEqual(resource.getQueryParameter("ARG1"), "VAL1");
+      assert.strictEqual(resource.getQueryParameter("ARG2"), "VAL2");
     });
   });
 


### PR DESCRIPTION
Many methods of the [Resource](https://github.com/SAP/odata-library/blob/master/lib/engine/Resource.js) class (and its derived classes) should return `this` context for the methods chaining but actually return [request](https://github.com/SAP/odata-library/blob/master/lib/engine/RequestDefinition.js) context instead.

For example this sample would not work:
```javascript
service.C_AllocationCycleTP
    .queryParameter("$format", "json")
    .queryParameter("$top", "10")
    .get();
```
source: https://github.com/SAP/odata-library/blob/master/doc/GET_ENTITY_SET.md#use-queryparameter

as after the first `queryParameter(...)` call the actual context is `this.defaultRequest` which does not contain the `queryParameter` method and would cause failure.

This PR fixes the return values of similar methods to keep the methods chaining working.