### PR TITLE
Use BaseType attribute to define EntityType key

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -57,7 +57,7 @@ function taskWatch(done) {
       usePolling: true,
       interval: 500,
     },
-    series(taskLocalPrettify, taskLocalUnit, taskLocalLint)
+    series(taskLocalUnit, taskLocalLint)
   );
   done();
 }
@@ -106,6 +106,7 @@ function taskFuncCI() {
 
 exports.local = series(taskLocalPrettify, taskLocalLint, taskLocalUnit);
 exports.validate = series(taskPrettifyCI, taskLocalLint, taskLocalUnit);
+exports.prettier = series(taskLocalPrettify);
 exports.watch = taskWatch;
 exports.default = series(
   taskPrettifyCI,

--- a/lib/engine/NavigationProperty.js
+++ b/lib/engine/NavigationProperty.js
@@ -45,6 +45,19 @@ class NavigationProperty extends QueryableResource {
   }
 
   /**
+   * Resets default request of the navigation property
+   * and "parent" entity set also
+   *
+   * @memberof NavigationProperty
+   *
+   * @protected
+   */
+  reset() {
+    QueryableResource.prototype.reset.call(this);
+    this.source.reset();
+  }
+
+  /**
    * Indicates of the NavigationProperty Multiplicity is multiple or not
    * @returns {Boolean} true if the multiplicity is *
    * @memberof NavigationProperty

--- a/lib/model/EdmxModel.js
+++ b/lib/model/EdmxModel.js
@@ -44,7 +44,7 @@ class EdmxModel {
     let CsdlSchema = EdmxModel.getSchemaTypeByVersion(version);
     let service = EdmxModel.getService(rawMetadata);
     let schemas = _.isArray(service.Schema)
-      ? service.Schema.map((s) => new CsdlSchema(s, settings))
+      ? service.Schema.map((s) => new CsdlSchema(s, settings, this))
       : [];
 
     // MC-EDMX allows 0, but OASIS-EDMX not

--- a/lib/model/oasis/CsdlSchema.js
+++ b/lib/model/oasis/CsdlSchema.js
@@ -6,7 +6,7 @@ const ComplexType = require("./schema/ComplexType");
 const CollectionType = require("./schema/CollectionType");
 const EdmSimpleType = require("./schema/EdmSimpleType");
 const EntityType = require("./schema/EntityType");
-const Function = require("./schema/Function");
+const FunctionType = require("./schema/Function");
 const EntityContainer = require("./dataSource/EntityContainer");
 const EnumType = require("./schema/EnumType");
 const TypeDefinition = require("./schema/TypeDefinition");
@@ -44,7 +44,7 @@ const childCollections = [
   {
     name: "functions",
     sourceElement: "Function",
-    Class: Function,
+    Class: FunctionType,
   },
   {
     name: "entityContainers",
@@ -52,67 +52,6 @@ const childCollections = [
     Class: EntityContainer,
   },
 ];
-
-function initChildProperties(schema) {
-  childCollections.forEach((collection) => {
-    let child = _.get(schema.raw, collection.sourceElement, []).map(
-      (t) => new collection.Class(t)
-    );
-    Object.defineProperty(schema, collection.name, {
-      get: () => child,
-    });
-  });
-}
-
-function initSchemaDependentProperties(schema) {
-  childCollections.forEach((collection) => {
-    let items = schema[collection.name];
-    if (items.length > 0 && items[0].initSchemaDependentProperties) {
-      items.forEach((item) => item.initSchemaDependentProperties(schema));
-    }
-  });
-}
-
-function matchPath(regex, path, name) {
-  let matches = regex.exec(path);
-
-  if (!matches) {
-    throw new Error(`Unknown ${name} format: ${path}`);
-  }
-
-  return matches;
-}
-
-function parseTypePath(targetPath) {
-  let collectionMatches = /Collection\((.+)\)/.exec(targetPath);
-  let matches = matchPath(
-    /([a-z0-9_\.]+)\.([a-z0-9_]+)$/i,
-    collectionMatches ? collectionMatches[1] : targetPath,
-    "type path"
-  );
-
-  return {
-    path: matches[0],
-    namespace: matches[1],
-    name: matches[2],
-    isCollection: !!collectionMatches,
-  };
-}
-
-function parseModelPath(targetPath) {
-  let matches = matchPath(
-    /^([a-z0-9_\.]+)\.([a-z0-9_]+)(\/|\/([a-z0-9_]+))?$/i,
-    targetPath,
-    "model path"
-  );
-
-  return {
-    path: matches[0],
-    namespace: matches[1],
-    element: matches[2],
-    subElement: matches[4],
-  };
-}
 
 /**
  * Top-level conceptual schema definition language (CSDL) construct that allows creation of a namespace.
@@ -126,9 +65,11 @@ class CsdlSchema {
    * Creates an instance of CsdlSchema.
    * @param {Object} rawMetadata raw metadata object for schema
    * @param {Object} [settings] (normalized) settings for the metadata, e.g. { strict: false } to ignore non critical errors
+   * @param {EdmxModel} metaModel root point of metadata in-memory structure
+   *
    * @memberof CsdlSchema
    */
-  constructor(rawMetadata, settings) {
+  constructor(rawMetadata, settings, metaModel) {
     Object.defineProperty(this, "raw", {
       get: () => rawMetadata,
     });
@@ -150,8 +91,8 @@ class CsdlSchema {
       get: () => settings,
     });
 
-    initChildProperties(this);
-    initSchemaDependentProperties(this);
+    CsdlSchema.initChildProperties(this, metaModel);
+    CsdlSchema.initSchemaDependentProperties(this);
     this.applyAnnotations(rawMetadata.Annotations);
   }
 
@@ -193,7 +134,7 @@ class CsdlSchema {
    * @memberof CsdlSchema
    */
   getType(name) {
-    let target = parseTypePath(name);
+    let target = CsdlSchema.parseTypePath(name);
     let type = this._getTypeCollections(target.namespace)
       .map((types) => types.find((t) => t.name === target.name))
       .find((t) => !!t);
@@ -223,7 +164,7 @@ class CsdlSchema {
    */
   resolveModelPath(path) {
     let target = this._parseModelPath(path);
-    var child = childCollections
+    let child = childCollections
       .map((collection) =>
         this[collection.name].find((item) => item.name === target.element)
       )
@@ -285,7 +226,7 @@ class CsdlSchema {
    * @private
    */
   _parseModelPath(path) {
-    let target = parseModelPath(path);
+    let target = CsdlSchema.parseModelPath(path);
 
     if (
       target.namespace !== this.namespace &&
@@ -355,6 +296,77 @@ class CsdlSchema {
         );
       }
     }
+  }
+
+  /**
+   * Initialize metadata collections (EntityType, Action,...)
+   *
+   * @param {CsdlSchema} schema - instance of the schema to append collections
+   * @param {EdmxModel} metaModel - instance of metadata model class. The instance
+   *        is passed to child instances for cross reference usage like basetype
+   *        and entity types from differnet schemas
+   */
+  static initChildProperties(schema, metaModel) {
+    childCollections.forEach((collection) => {
+      let child = _.get(schema.raw, collection.sourceElement, []).map(
+        (typeRawMetadata) => {
+          return new collection.Class(typeRawMetadata, metaModel);
+        }
+      );
+      Object.defineProperty(schema, collection.name, {
+        get: () => child,
+      });
+    });
+  }
+
+  static initSchemaDependentProperties(schema) {
+    childCollections.forEach((collection) => {
+      let items = schema[collection.name];
+      if (items.length > 0 && items[0].initSchemaDependentProperties) {
+        items.forEach((item) => item.initSchemaDependentProperties(schema));
+      }
+    });
+  }
+
+  static matchPath(regex, path, name) {
+    let matches = regex.exec(path);
+
+    if (!matches) {
+      throw new Error(`Unknown ${name} format: ${path}`);
+    }
+
+    return matches;
+  }
+
+  static parseTypePath(targetPath) {
+    let collectionMatches = /Collection\((.+)\)/.exec(targetPath);
+    let matches = CsdlSchema.matchPath(
+      /([a-z0-9_\.]+)\.([a-z0-9_]+)$/i,
+      collectionMatches ? collectionMatches[1] : targetPath,
+      "type path"
+    );
+
+    return {
+      path: matches[0],
+      namespace: matches[1],
+      name: matches[2],
+      isCollection: !!collectionMatches,
+    };
+  }
+
+  static parseModelPath(targetPath) {
+    let matches = CsdlSchema.matchPath(
+      /^([a-z0-9_\.]+)\.([a-z0-9_]+)(\/|\/([a-z0-9_]+))?$/i,
+      targetPath,
+      "model path"
+    );
+
+    return {
+      path: matches[0],
+      namespace: matches[1],
+      element: matches[2],
+      subElement: matches[4],
+    };
   }
 }
 

--- a/lib/model/oasis/schema/Action.js
+++ b/lib/model/oasis/schema/Action.js
@@ -89,6 +89,16 @@ class Action extends AnnotationTarget {
       );
     }
   }
+
+  /**
+   * Resolves model path within this type.
+   *
+   * @returns {Object} itself
+   * @memberof Function
+   */
+  resolveModelPath() {
+    return this;
+  }
 }
 
 module.exports = Action;

--- a/lib/model/oasis/schema/EntityType.js
+++ b/lib/model/oasis/schema/EntityType.js
@@ -14,15 +14,23 @@ const ComplexType = require("./ComplexType");
 class EntityType extends ComplexType {
   /**
    * Creates an instance of EntityType.
+   *
    * @param {Object} rawMetadata raw metadata object for complex type
+   * @param {EdmxModel} metaModel root point of metadata in-memory structure
+   *
    * @memberof EntityType
    */
-  constructor(rawMetadata) {
+  constructor(rawMetadata, metaModel) {
     super(rawMetadata);
 
-    let key = this._createKey();
+    let key;
     Object.defineProperty(this, "key", {
-      get: () => key,
+      get: () => {
+        if (!key) {
+          key = this._createKey(metaModel);
+        }
+        return key;
+      },
     });
   }
 
@@ -42,24 +50,52 @@ class EntityType extends ComplexType {
    * Creates entity type 'key' property.
    *
    * @returns {Property[]} array of properties that defines entity key
+   * @param {EdmxModel} metaModel root point of metadata in-memory structure
    *
    * @memberof EntityType
    *
    * @private
    */
-  _createKey() {
-    if (
-      !_.has(this.raw, "Key") ||
-      !_.isArray(this.raw.Key) ||
-      this.raw.Key.length !== 1
-    ) {
+  _createKey(metaModel) {
+    let key;
+    let baseType = _.get(this, "raw.$.BaseType");
+    let keyDefinition = _.get(this, "raw.Key");
+
+    if (!this.isValidKeyDefinition(baseType, keyDefinition)) {
       // actually this is true only for base types, derived types inherits the key and can't define key entity
       throw new Error(
         `The EntityType ${this.name} has incorrect key definition.`
       );
     }
 
-    return this.raw.Key[0].PropertyRef.map((pr) => this.getProperty(pr.$.Name));
+    if (_.isString(baseType)) {
+      key = metaModel.resolveModelPath(baseType).key;
+    } else {
+      key = keyDefinition[0].PropertyRef.map((pr) =>
+        this.getProperty(pr.$.Name)
+      );
+    }
+
+    return key;
+  }
+
+  /**
+   * Check if key parameters are correct to build key
+   *
+   * @param {String} baseType name of OData service base type
+   * @param {Object[]} keyDefinition raw key definition
+   *
+   * @returns {Boolean} returns true for valid parameters
+   *
+   * @memberof EntityType
+   *
+   * @private
+   */
+  isValidKeyDefinition(baseType, keyDefinition) {
+    return (
+      _.isString(baseType) ||
+      (_.isArray(keyDefinition) && keyDefinition.length === 1)
+    );
   }
 }
 

--- a/lib/model/oasis/schema/Function.js
+++ b/lib/model/oasis/schema/Function.js
@@ -72,6 +72,16 @@ class Function extends AnnotationTarget {
     this.parameters.forEach((p) => p.initSchemaDependentProperties(schema));
     return this;
   }
+
+  /**
+   * Resolves model path within this type.
+   *
+   * @returns {Object} itself
+   * @memberof Function
+   */
+  resolveModelPath() {
+    return this;
+  }
 }
 
 module.exports = Function;

--- a/test/unit/engine/NavigationProperty.js
+++ b/test/unit/engine/NavigationProperty.js
@@ -5,6 +5,7 @@ const sinon = require("sinon");
 const _ = require("lodash");
 const NavigationProperty = require("../../../lib/engine/NavigationProperty");
 const Parent = require("../../../lib/engine/QueryableResource");
+const sandbox = sinon.createSandbox();
 
 describe("NavigationProperty", function () {
   let navigationProperty;
@@ -61,6 +62,10 @@ describe("NavigationProperty", function () {
         },
       }
     );
+  });
+
+  afterEach(function () {
+    sandbox.restore();
   });
 
   describe("#constructor()", function () {
@@ -407,5 +412,15 @@ describe("NavigationProperty", function () {
         navigationPropertyMD
       ) instanceof NavigationProperty
     );
+  });
+
+  it(".reset()", function () {
+    navigationProperty._requestDefinition = "REQUEST_DEFINITION";
+    innerSource.reset = sinon.stub();
+    sandbox.spy(Parent.prototype, "reset");
+    navigationProperty.reset();
+    assert.strictEqual(navigationProperty._requestDefinition, undefined);
+    assert.ok(innerSource.reset.called);
+    assert.ok(Parent.prototype.reset.called);
   });
 });

--- a/test/unit/model/oasis/CsdlSchemaNoDependencies.js
+++ b/test/unit/model/oasis/CsdlSchemaNoDependencies.js
@@ -1,0 +1,69 @@
+"use strict";
+
+const assert = require("assert").strict;
+const sinon = require("sinon");
+const proxyquire = require("proxyquire");
+const sandbox = sinon.createSandbox();
+
+describe("CsdlSchema", function () {
+  let rawMetadata = {
+    $: {
+      Alias: "ALIAS",
+      Namespace: "NAMESPACE",
+    },
+    Annotations: "ANNOTATIONS",
+  };
+  let settings = {};
+  let schema;
+  let CsdlSchema;
+  let EnumType = sinon.stub();
+
+  beforeEach(function () {
+    CsdlSchema = proxyquire("../../../../lib/model/oasis/CsdlSchema", {
+      "./schema/EnumType": EnumType,
+    });
+    sandbox.stub(CsdlSchema.prototype, "applyAnnotations");
+    sandbox.stub(CsdlSchema, "initChildProperties");
+    sandbox.stub(CsdlSchema, "initSchemaDependentProperties");
+    schema = new CsdlSchema(rawMetadata, settings, "META_MODEL");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it(".constructor()", function () {
+    assert.equal(schema.raw, rawMetadata);
+    assert.equal(schema.settings, settings);
+    assert.equal(schema.alias, "ALIAS");
+    assert.equal(schema.namespace, "NAMESPACE");
+    assert.deepEqual(schema.extensions, []);
+    assert.ok(CsdlSchema.initChildProperties.calledWith(schema, "META_MODEL"));
+    assert.ok(CsdlSchema.initSchemaDependentProperties.calledWith(schema));
+    assert.ok(schema.applyAnnotations.calledWith("ANNOTATIONS"));
+  });
+
+  describe("#initChildProperties()", function () {
+    it("empty child property", () => {
+      schema = {
+        raw: {
+          EnumType: [],
+        },
+      };
+      CsdlSchema.initChildProperties.restore();
+      CsdlSchema.initChildProperties(schema, "RAW_METADATA");
+      assert.deepEqual(schema.enumTypes, []);
+    });
+    it("correctly create child", () => {
+      schema = {
+        raw: {
+          EnumType: ["ENUM"],
+        },
+      };
+      CsdlSchema.initChildProperties.restore();
+      CsdlSchema.initChildProperties(schema, "RAW_METADATA");
+      assert.strictEqual(schema.enumTypes.length, 1);
+      assert.ok(EnumType.calledWith("ENUM", "RAW_METADATA"));
+    });
+  });
+});

--- a/test/unit/model/oasis/schema/Action.js
+++ b/test/unit/model/oasis/schema/Action.js
@@ -39,22 +39,25 @@ const schema = {
 };
 
 describe("Action", function () {
+  let actionType;
+  beforeEach(() => {
+    actionType = new Action(sampleMD);
+  });
   describe("#constructor()", function () {
     it("initializes properties", function () {
-      let fn = new Action(sampleMD);
-      assert.equal(fn.raw, sampleMD);
-      assert.equal(fn.name, "Action1");
-      assert.ok(fn.isBound);
-      assert.equal(fn.entitySetPath, "path");
-      assert.ok(_.isArray(fn.parameters));
+      assert.equal(actionType.raw, sampleMD);
+      assert.equal(actionType.name, "Action1");
+      assert.ok(actionType.isBound);
+      assert.equal(actionType.entitySetPath, "path");
+      assert.ok(_.isArray(actionType.parameters));
     });
 
     it("uses properties' defaults", function () {
-      let fn = new Action(sampleMinimalMD);
-      assert.equal(fn.raw, sampleMinimalMD);
-      assert.equal(fn.name, "Action1");
-      assert.ok(!fn.isBound);
-      assert.ok(_.isArray(fn.parameters));
+      actionType = new Action(sampleMinimalMD);
+      assert.equal(actionType.raw, sampleMinimalMD);
+      assert.equal(actionType.name, "Action1");
+      assert.ok(!actionType.isBound);
+      assert.ok(_.isArray(actionType.parameters));
     });
 
     it("entityTypePath", function () {
@@ -115,13 +118,16 @@ describe("Action", function () {
 
   describe(".initSchemaDependentProperties()", function () {
     it("initializes return type and parameters", function () {
-      let fn = new Action(sampleMD);
-      fn.initSchemaDependentProperties(schema);
-      assert.equal(fn.returnType.type, type);
-      assert.equal(fn.parameters[0].type, type);
+      actionType.initSchemaDependentProperties(schema);
+      assert.equal(actionType.returnType.type, type);
+      assert.equal(actionType.parameters[0].type, type);
 
-      fn = new Action(sampleMinimalMD);
-      fn.initSchemaDependentProperties(schema);
+      actionType = new Action(sampleMinimalMD);
+      actionType.initSchemaDependentProperties(schema);
     });
+  });
+
+  it(".resolveModelPath()", function () {
+    assert.strictEqual(actionType.resolveModelPath(), actionType);
   });
 });

--- a/test/unit/model/oasis/schema/EntityType.js
+++ b/test/unit/model/oasis/schema/EntityType.js
@@ -84,7 +84,7 @@ function createSchema(type) {
   };
 }
 
-describe("EntityType (nw)", function () {
+describe("EntityType (oasis)", function () {
   let type;
   beforeEach(function () {
     type = new EntityType(sampleEntityTypeMD);

--- a/test/unit/model/oasis/schema/EntityTypeNoDependencies.js
+++ b/test/unit/model/oasis/schema/EntityTypeNoDependencies.js
@@ -1,0 +1,80 @@
+"use strict";
+
+const assert = require("assert").strict;
+const sinon = require("sinon");
+const EntityType = require("../../../../../lib/model/oasis/schema/EntityType");
+
+describe("EntityType (OASIS) no dependencies", function () {
+  let type;
+  let rawMetadata;
+  let metaModel;
+  beforeEach(function () {
+    metaModel = {};
+    rawMetadata = {
+      $: {
+        Name: "NAME",
+      },
+    };
+    type = new EntityType(rawMetadata, metaModel);
+  });
+
+  it("#constructor()", function () {
+    sinon.stub(type, "_createKey").returns("KEY");
+    assert.equal(type.key, "KEY");
+    assert.equal(type.key, "KEY");
+    assert.ok(type._createKey.calledOnce);
+    assert.ok(type._createKey.calledWith(metaModel));
+  });
+
+  describe(".createKey()", function () {
+    it("local key definition", function () {
+      sinon.stub(type, "getProperty").returns("PROPERTY_INSTANCE");
+      rawMetadata.Key = [
+        {
+          PropertyRef: [
+            {
+              $: "PROPERTY_NAME",
+            },
+          ],
+        },
+      ];
+      assert.deepEqual(type._createKey(metaModel), ["PROPERTY_INSTANCE"]);
+    });
+    it("base type key definition", function () {
+      metaModel.resolveModelPath = sinon.stub().returns({
+        key: ["BASE_PROPERTY_INSTANCE"],
+      });
+      rawMetadata.$.BaseType = "BASE_TYPE";
+      assert.deepEqual(type._createKey(metaModel), ["BASE_PROPERTY_INSTANCE"]);
+    });
+
+    it("Invalid key definition", function () {
+      sinon.stub(type, "isValidKeyDefinition").returns(true);
+      assert.throws(() => {
+        type._createKey(metaModel);
+      });
+    });
+  });
+
+  it(".isValidKeyDefinition()", function () {
+    [
+      {
+        args: ["BaseType", null],
+        result: true,
+      },
+      {
+        args: [null, ["KEY_DEF"]],
+        result: true,
+      },
+      {
+        args: [null, null],
+        result: false,
+      },
+    ].forEach((testCase) => {
+      assert.equal(
+        type.isValidKeyDefinition(...testCase.args),
+        testCase.result
+      );
+    });
+  });
+});

--- a/test/unit/model/oasis/schema/Function.js
+++ b/test/unit/model/oasis/schema/Function.js
@@ -47,24 +47,28 @@ const schema = {
 };
 
 describe("Function", function () {
+  let functionImportType;
+  beforeEach(() => {
+    functionImportType = new FunctionDef(sampleMD);
+  });
   describe("#constructor()", function () {
     it("initializes properties", function () {
-      let fn = new FunctionDef(sampleMD);
-      assert.equal(fn.raw, sampleMD);
-      assert.equal(fn.name, "Function1");
-      assert.ok(fn.isBound);
-      assert.ok(fn.isComposable);
-      assert.equal(fn.entitySetPath, "path");
-      assert.ok(_.isArray(fn.parameters));
+      functionImportType = new FunctionDef(sampleMD);
+      assert.equal(functionImportType.raw, sampleMD);
+      assert.equal(functionImportType.name, "Function1");
+      assert.ok(functionImportType.isBound);
+      assert.ok(functionImportType.isComposable);
+      assert.equal(functionImportType.entitySetPath, "path");
+      assert.ok(_.isArray(functionImportType.parameters));
     });
 
     it("uses properties' defaults", function () {
-      let fn = new FunctionDef(sampleMinimalMD);
-      assert.equal(fn.raw, sampleMinimalMD);
-      assert.equal(fn.name, "Function1");
-      assert.ok(!fn.isBound);
-      assert.ok(!fn.isComposable);
-      assert.ok(_.isArray(fn.parameters));
+      functionImportType = new FunctionDef(sampleMinimalMD);
+      assert.equal(functionImportType.raw, sampleMinimalMD);
+      assert.equal(functionImportType.name, "Function1");
+      assert.ok(!functionImportType.isBound);
+      assert.ok(!functionImportType.isComposable);
+      assert.ok(_.isArray(functionImportType.parameters));
     });
 
     it("throws error on missing name or return type", function () {
@@ -94,10 +98,16 @@ describe("Function", function () {
 
   describe(".initSchemaDependentProperties()", function () {
     it("initializes return type and parameters", function () {
-      let fn = new FunctionDef(sampleMD);
-      fn.initSchemaDependentProperties(schema);
-      assert.equal(fn.returnType.type, type);
-      assert.equal(fn.parameters[0].type, type);
+      functionImportType.initSchemaDependentProperties(schema);
+      assert.equal(functionImportType.returnType.type, type);
+      assert.equal(functionImportType.parameters[0].type, type);
     });
+  });
+
+  it(".resolveModelPath()", function () {
+    assert.strictEqual(
+      functionImportType.resolveModelPath(),
+      functionImportType
+    );
   });
 });


### PR DESCRIPTION
Share one Entity(Complex) type definition by more EntityTypes. 
Correctly process Action/FunctionImport type definition with namespace
Cleans request definition for NavigationProperty "parent" EntitySet.