### PR TITLE
[FIX] Parse PropertyPath with Navigation Property

### DIFF
--- a/lib/model/nw/extensions/sap/EntityTypeExtender.js
+++ b/lib/model/nw/extensions/sap/EntityTypeExtender.js
@@ -68,11 +68,11 @@ function createPropertyExtension(property, schema, settings) {
   return extension;
 }
 
-function createEntityTypeCommonExtension(entityType) {
+function createEntityTypeCommonExtension(entityType, schema) {
   return {
     sideEffects: entityType.annotations
       .filter((a) => a.term === "Common.SideEffects")
-      .map((a) => new SideEffectsType(a, entityType)),
+      .map((a) => new SideEffectsType(a, entityType, schema)),
   };
 }
 
@@ -113,7 +113,7 @@ class EntityTypeExtender {
   static process(entityType, schema, settings) {
     ExtenderBase.applyAttributeExtension(entityType, ATTRIBUTES_ENTITY_TYPE);
 
-    entityType.sap.common = createEntityTypeCommonExtension(entityType);
+    entityType.sap.common = createEntityTypeCommonExtension(entityType, schema);
     entityType.sap.ui = createEntityTypeUIExtension(entityType);
 
     entityType.properties.forEach((p) =>
@@ -128,5 +128,9 @@ class EntityTypeExtender {
     );
   }
 }
+
+EntityTypeExtender._ = {
+  createEntityTypeCommonExtension: createEntityTypeCommonExtension,
+};
 
 module.exports = EntityTypeExtender;

--- a/lib/model/nw/extensions/sap/common/SideEffectsType.js
+++ b/lib/model/nw/extensions/sap/common/SideEffectsType.js
@@ -25,26 +25,48 @@ class SideEffectsType {
    * Creates an instance of SideEffectsType.
    * @param {Annotation} [annotation] side effects
    * @param {EntityType} [entityType] target entity type
+   * @param {CsdlSchema} [schema] parent schema
    * @memberof SideEffectsType
    */
-  constructor(annotation, entityType) {
+  constructor(annotation, entityType, schema) {
     Object.defineProperty(this, "annotation", {
       get: () => annotation,
     });
 
-    definePropertyCollection(this, "SourceEntities", (p) =>
+    SideEffectsType._.definePropertyCollection(this, "SourceEntities", (p) =>
       entityType.getNavigationProperty(p)
     );
-    definePropertyCollection(this, "SourceProperties", (p) =>
+    SideEffectsType._.definePropertyCollection(this, "SourceProperties", (p) =>
       entityType.getProperty(p)
     );
-    definePropertyCollection(this, "TargetEntities", (p) =>
+    SideEffectsType._.definePropertyCollection(this, "TargetEntities", (p) =>
       entityType.getNavigationProperty(p)
     );
-    definePropertyCollection(this, "TargetProperties", (p) =>
-      entityType.getProperty(p)
+    SideEffectsType._.definePropertyCollection(
+      this,
+      "TargetProperties",
+      (p) => {
+        let propertyName;
+        let navigationPropertyName;
+        let foundProperty;
+        let isNavigationProperty = _.isString(p) && p.split("/").length === 2;
+        if (isNavigationProperty) {
+          [navigationPropertyName, propertyName] = p.split("/");
+          foundProperty = entityType
+            .getNavigationProperty(navigationPropertyName)
+            .getTarget(schema)
+            .entityType.getProperty(propertyName);
+        } else {
+          foundProperty = entityType.getProperty(p);
+        }
+        return foundProperty;
+      }
     );
   }
 }
+
+SideEffectsType._ = {
+  definePropertyCollection: definePropertyCollection,
+};
 
 module.exports = SideEffectsType;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sap_oss/odata-library",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "OData client for testing Netweawer OData services.",
   "main": "index.js",
   "dependencies": {

--- a/test/unit/model/nw/extensions/sap/common/SideEffectsType.js
+++ b/test/unit/model/nw/extensions/sap/common/SideEffectsType.js
@@ -1,34 +1,42 @@
 "use strict";
 
-const assert = require("assert");
+const assert = require("assert").strict;
 const SideEffectsType = require("../../../../../../../lib/model/nw/extensions/sap/common/SideEffectsType");
-
-let annotation = {
-  record: {
-    value: {
-      SourceEntities: {
-        collection: ["a"],
-      },
-      SourceProperties: {
-        collection: ["a"],
-      },
-      TargetEntities: {
-        collection: ["a", "b"],
-      },
-      TargetProperties: {
-        collection: ["a", "b"],
-      },
-    },
-  },
-};
-
-let entityType = {
-  getNavigationProperty: () => "navProp",
-  getProperty: () => "prop",
-};
+const sinon = require("sinon");
+const sandbox = sinon.createSandbox();
 
 describe("SideEffectsType", function () {
+  afterEach(function () {
+    sandbox.restore();
+  });
   describe("#constructor()", function () {
+    let entityType;
+    let annotation = {
+      record: {
+        value: {
+          SourceEntities: {
+            collection: ["a"],
+          },
+          SourceProperties: {
+            collection: ["a"],
+          },
+          TargetEntities: {
+            collection: ["a", "b"],
+          },
+          TargetProperties: {
+            collection: ["a", "b"],
+          },
+        },
+      },
+    };
+
+    beforeEach(function () {
+      entityType = {
+        getNavigationProperty: () => "navProp",
+        getProperty: () => "prop",
+      };
+    });
+
     it("initializes properties", function () {
       let sideEffects = new SideEffectsType(annotation, entityType);
 
@@ -48,6 +56,43 @@ describe("SideEffectsType", function () {
       assert.strictEqual(sideEffects.sourceProperties[0], "prop");
       assert.strictEqual(sideEffects.targetEntities[0], "navProp");
       assert.strictEqual(sideEffects.targetProperties[0], "prop");
+    });
+
+    it("define target property as path", function () {
+      let sideEffects;
+      let transformer;
+      let target = {
+        entityType: {
+          getProperty: sinon
+            .stub()
+            .returns("PROPERTY_FROM_NAVIGATION_PROPERTY"),
+        },
+      };
+      let navigationProperty = {
+        getTarget: sinon.stub().returns(target),
+      };
+
+      sandbox.stub(SideEffectsType._, "definePropertyCollection");
+      sideEffects = new SideEffectsType(annotation, entityType, "SCHEMA");
+      assert.ok(
+        SideEffectsType._.definePropertyCollection
+          .getCall(3)
+          .calledWith(sideEffects, "TargetProperties")
+      );
+      transformer = SideEffectsType._.definePropertyCollection.getCall(3)
+        .args[2];
+
+      entityType.getProperty = sinon.stub().returns("PROPERTY");
+      entityType.getNavigationProperty = sinon
+        .stub()
+        .returns(navigationProperty);
+
+      assert.equal(
+        transformer("navigationPropertyName/propertyName"),
+        "PROPERTY_FROM_NAVIGATION_PROPERTY"
+      );
+      assert.ok(navigationProperty.getTarget.calledWithExactly("SCHEMA"));
+      assert.ok(entityType.getProperty.notCalled);
     });
   });
 });


### PR DESCRIPTION
Annotations could define property as path with
link to property from navigation property property
instead of link to own property. The patch implements
finding of the property in navigation property.

Topic: #20