### PR TITLE
[FEATURE] PUT method for OData 3.0 and newer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 0.9.12
+
+  * f5edbb3 - [FEATURE] PUT method for OData 3.0 and newer - Norbert Volf
+  * 58bb17b - [FIX] Parse PropertyPath with Navigation Property - Norbert Volf
+
 # 0.9.11
 
   * a01c938 - [FIX] Set headers before request definition - Norbert Volf

--- a/doc/ACTIVE_OPERATIONS.md
+++ b/doc/ACTIVE_OPERATIONS.md
@@ -50,15 +50,23 @@ Use Association.post to create a new entry referenced by already initialized Ent
 
 # Update entity
 
-Use EntitySet.merge to update properties of an entity. The object
-passed as parameter of the EntitySet.merge method should contain
+OData protocol versions 1.0 and 2.0 define "MERGE" HTTP method to update
+existing entity. Newer versions of OData protocol define "PATCH"
+HTTP method to update existing entity. EntitySet supports both HTTP
+methods. The EntitySet does not check current version of the OData
+protocol version. You can try use *patch* for OData 2.0 also. You
+are limited by server implementation only. EntitySet.patch and
+EntitySet.merge are synonyms.
+
+Use merge or patch to update properties of an entity. The object
+passed as parameter of the merge or patch method should contains
 entries of the entity's key properties and entries of properties,
 which are supposed to be updated.
 
 ```javascript
     let service  = new Service();
 	return service .C_PaymentRequest
-		.merge({
+		.patch({
 			"PaymentRequest": "861",
 			"DraftUUID": "0894ef30-1ccd-1ed8-bdde-86bb77adbb96",
 			"IsActiveEntity": false,
@@ -68,9 +76,9 @@ which are supposed to be updated.
 	});
 ```
 
-Merge could be callaed with two parameter. First parameter contains
-key and second parameter contains object with properties for changes.
-It is useful for chaining.
+merge and patch could be called with two parameter also. First parameter
+contains key and second parameter contains object with properties
+to change.  It is useful for chaining.
 
 ```javascript
     let service  = new Service();
@@ -88,9 +96,9 @@ It is useful for chaining.
 		});
 ```
 
-# Update entity (entire resource)
+# Replace entity (entire resource)
 
-Use EntitySet.put to update an entity by replacing its content.
+Use EntitySet.put to replace an entity by replacing its content.
 The entity content is replaced by a new content from object
 passed as parameter of the EntitySet.put method.
 

--- a/lib/agent/Agent.js
+++ b/lib/agent/Agent.js
@@ -476,7 +476,8 @@ class Agent {
   }
 
   /**
-   * Wrapper around MERGE function. All parameters are passed to superagent
+   * Wrapper around MERGE function. All parameters are passed to superagent. MERGE request
+   * is supported by OData protocol 2.0 and older.
    *
    * @param {String} inputUrl relative path in the service
    * @param {Object} headers object which contains headers used for the MERGE request
@@ -489,6 +490,23 @@ class Agent {
    */
   merge(...args) {
     return this.sendRequest("MERGE", ...args);
+  }
+
+  /**
+   * Create PATCH request. Patch updates the entity. It is supported by OData protocol
+   * version 3.0 and newer.
+   *
+   * @param {String} inputUrl relative path in the service
+   * @param {Object} headers object which contains headers used for the GET request
+   * @param {Object} payload data which is converted to the JSON string and passed as body of MERGE request in batch
+   *
+   * @returns {Promise} promise which done when PATCH request has finished
+   *
+   * @public
+   * @memberof Agent
+   */
+  patch(...args) {
+    return this.sendRequest("PATCH", ...args);
   }
 
   /**

--- a/lib/agent/batch/Batch.js
+++ b/lib/agent/batch/Batch.js
@@ -50,6 +50,40 @@ class Batch extends Base {
   }
 
   /**
+   * Create request in batch with payload
+   *
+   * @param {String} httpMethod name of the HTTP method
+   * @param {String} inputUrl relative path in the service
+   * @param {Object} headers object which contains headers used for the GET request
+   * @param {Object} payload data which is converted to the JSON string and passed as body of POST request
+   * @param {batch/ChangeSet} changeSet which contains newly created request
+   *
+   * @returns {batch/Request} instance of batch Request
+   *
+   * @private
+   * @memberof Agent
+   */
+  addRequestWithPayload(httpMethod, inputUrl, headers, payload, changeSet) {
+    return this.addRequest(
+      httpMethod,
+      inputUrl,
+      _.assign(
+        {
+          "sap-contextid-accept": "header",
+          Accept: "application/json",
+          DataServiceVersion: "2.0",
+          MaxDataServiceVersion: "2.0",
+          "Content-Type": "application/json",
+          "sap-message-scope": "BusinessObject",
+        },
+        headers
+      ),
+      payload,
+      changeSet
+    );
+  }
+
+  /**
    * Try to find passed changeSet in the current batch. If changeSet is not
    * defined and the batch contains only one batch. Use it.
    *
@@ -204,30 +238,15 @@ class Batch extends Base {
    *
    * @returns {batch/Request} instance of batch Request
    *
+   * @public
    * @memberof Agent
    */
-  post(inputUrl, headers, payload, changeSet) {
-    return this.addRequest(
-      "POST",
-      inputUrl,
-      _.assign(
-        {
-          "sap-contextid-accept": "header",
-          Accept: "application/json",
-          DataServiceVersion: "2.0",
-          MaxDataServiceVersion: "2.0",
-          "Content-Type": "application/json",
-          "sap-message-scope": "BusinessObject",
-        },
-        headers
-      ),
-      payload,
-      changeSet
-    );
+  post(...args) {
+    return this.addRequestWithPayload("POST", ...args);
   }
 
   /**
-   * Create PUT request in batch
+   * Create PUT request in batch. The PUT request replaces entity by OData protocol
    *
    * @param {String} inputUrl relative path in the service
    * @param {Object} headers object which contains headers used for the GET request
@@ -236,30 +255,16 @@ class Batch extends Base {
    *
    * @returns {batch/Request} instance of batch Request
    *
+   * @public
    * @memberof Agent
    */
-  put(inputUrl, headers, payload, changeSet) {
-    return this.addRequest(
-      "PUT",
-      inputUrl,
-      _.assign(
-        {
-          "sap-contextid-accept": "header",
-          Accept: "application/json",
-          DataServiceVersion: "2.0",
-          MaxDataServiceVersion: "2.0",
-          "Content-Type": "application/json",
-          "sap-message-scope": "BusinessObject",
-        },
-        headers
-      ),
-      payload,
-      changeSet
-    );
+  put(...args) {
+    return this.addRequestWithPayload("PUT", ...args);
   }
 
   /**
-   * Create MERGE request in batch
+   * Create MERGE request in batch. MERGE updates the entity.
+   * It is supported by OData protocol 1.0 and 2.0
    *
    * @param {String} inputUrl relative path in the service
    * @param {Object} headers object which contains headers used for the GET request
@@ -268,26 +273,29 @@ class Batch extends Base {
    *
    * @returns {batch/Request} instance of batch Request
    *
+   * @public
    * @memberof Agent
    */
-  merge(inputUrl, headers, payload, changeSet) {
-    return this.addRequest(
-      "MERGE",
-      inputUrl,
-      _.assign(
-        {
-          "sap-contextid-accept": "header",
-          Accept: "application/json",
-          DataServiceVersion: "2.0",
-          MaxDataServiceVersion: "2.0",
-          "Content-Type": "application/json",
-          "sap-message-scope": "BusinessObject",
-        },
-        headers
-      ),
-      payload,
-      changeSet
-    );
+  merge(...args) {
+    return this.addRequestWithPayload("MERGE", ...args);
+  }
+
+  /**
+   * Create PATCH request in batch. Patch updates the entity.
+   * It is supported by OData protocol version 3.0 and later.
+   *
+   * @param {String} inputUrl relative path in the service
+   * @param {Object} headers object which contains headers used for the GET request
+   * @param {Object} payload data which is converted to the JSON string and passed as body of MERGE request in batch
+   * @param {batch/ChangeSet} changeSet which contains newly created request
+   *
+   * @returns {batch/Request} instance of batch Request
+   *
+   * @public
+   * @memberof Agent
+   */
+  patch(...args) {
+    return this.addRequestWithPayload("PATCH", ...args);
   }
 
   /**

--- a/lib/engine/QueryableResource.js
+++ b/lib/engine/QueryableResource.js
@@ -233,6 +233,22 @@ class QueryableResource extends Resource {
   }
 
   /**
+   * Send request to update an entity by HTTP MERGE method (update for
+   * OData protocol version 1.0-2.0)
+   *
+   * @param {Object} body map of key properties and new data for the entity
+   * @param {Object} [propertiesToChange] map of new data for the entity
+   *
+   * @return {Promise} returned promise is resolved when request is finished
+   * Promise is resolved with response object which doesn't contain body
+   *
+   * @memberof QueryableResource
+   */
+  merge(...args) {
+    return this.processUpdateCall("merge", ...args);
+  }
+
+  /**
    * Send request to update an entity by HTTP MERGE method
    *
    * @param {Object} body map of key properties and new data for the entity
@@ -243,7 +259,25 @@ class QueryableResource extends Resource {
    *
    * @memberof QueryableResource
    */
-  merge() {
+  patch(...args) {
+    return this.processUpdateCall("patch", ...args);
+  }
+
+  /**
+   * Send request to update entity via MERGE or PATCH method. The method
+   * unify code for patch and merge methods.
+   *
+   * @param {String} methodName name of method from agent "merge" or "patch"
+   * @param {Object} body map of key properties and new data for the entity
+   * @param {Object} [propertiesToChange] map of new data for the entity
+   *
+   * @return {Promise} returned promise is resolved when request is finished
+   * Promise is resolved with response object which doesn't contain body
+   *
+   * @private
+   * @memberof QueryableResource
+   */
+  processUpdateCall(methodName, ...args) {
     let keyProperties;
     let keyPredicate;
     let propertiesToChange;
@@ -252,10 +286,10 @@ class QueryableResource extends Resource {
     let defaultBatch = this.agent.batchManager.defaultBatch;
     let defaultChangeSet = this.agent.batchManager.defaultChangeSet;
 
-    if (arguments.length === 0 || arguments.length > 2) {
-      throw new Error("Invalid body parameter for merge.");
-    } else if (arguments.length === 1) {
-      entity = _.assign({}, arguments[0], this.defaultRequest._keyValue);
+    if (args.length === 0 || args.length > 2) {
+      throw new Error(`Invalid body parameter for ${methodName}.`);
+    } else if (args.length === 1) {
+      entity = _.assign({}, args[0], this.defaultRequest._keyValue);
       keyProperties = this.keyProperties(entity);
       keyPredicate = this.keyPredicate(keyProperties);
       propertiesToChange = _.pickBy(
@@ -263,10 +297,10 @@ class QueryableResource extends Resource {
         (value, key) => !_.has(keyProperties, key)
       );
     } else {
-      keyProperties = this.keyProperties(arguments[0]);
+      keyProperties = this.keyProperties(args[0]);
       keyPredicate = this.keyPredicate(keyProperties);
       // note: following assignment allows to change also properties which are part of the key
-      propertiesToChange = arguments[1];
+      propertiesToChange = args[1];
     }
 
     path = `/${this.entitySetModel.name}(${keyPredicate})`;
@@ -275,7 +309,7 @@ class QueryableResource extends Resource {
     return defaultBatch
       ? this._handleBatchCall(() => {
           this.defaultRequest.header("Accept", "application/json");
-          return defaultBatch.merge(
+          return defaultBatch[methodName](
             path,
             this.defaultRequest._headers,
             this.defaultRequest._payload,
@@ -284,7 +318,7 @@ class QueryableResource extends Resource {
         }, defaultBatch)
       : this._handleAgentCall(() => {
           this.header("Content-type", "application/json");
-          return this.agent.merge(
+          return this.agent[methodName](
             path,
             this.defaultRequest._headers,
             this.defaultRequest._payload

--- a/test/unit/agent/Agent.js
+++ b/test/unit/agent/Agent.js
@@ -496,6 +496,14 @@ describe("Agent", function () {
     );
   });
 
+  it(".patch()", function () {
+    sinon.stub(agent, "sendRequest").returns("PROMISE");
+    assert.equal(agent.patch("INPUT_PATH", "HEADERS", "PAYLOAD"), "PROMISE");
+    assert.ok(
+      agent.sendRequest.calledWith("PATCH", "INPUT_PATH", "HEADERS", "PAYLOAD")
+    );
+  });
+
   it(".get()", function () {
     sinon.stub(agent, "sendRequest").returns("PROMISE");
     assert.equal(agent.get("INPUT_PATH", "HEADERS", "ARG1", "ARG2"), "PROMISE");

--- a/test/unit/agent/batch/Batch.js
+++ b/test/unit/agent/batch/Batch.js
@@ -235,6 +235,29 @@ describe("agent/batch/Batch", function () {
     });
   });
 
+  it(".patch", function () {
+    sinon.stub(batch, "addRequestWithPayload").returns("REQUEST");
+    batch.patch(
+      "INPUT_URL",
+      {
+        NAME: "VALUE",
+      },
+      "PAYLOAD",
+      "CHANGE_SET"
+    );
+    assert.ok(
+      batch.addRequestWithPayload.calledWith(
+        "PATCH",
+        "INPUT_URL",
+        {
+          NAME: "VALUE",
+        },
+        "PAYLOAD",
+        "CHANGE_SET"
+      )
+    );
+  });
+
   it(".delete", function () {
     sinon.stub(batch, "addRequest");
     batch.delete("INPUT_URL", "HEADERS", "CHANGE_SET");
@@ -244,6 +267,39 @@ describe("agent/batch/Batch", function () {
         "INPUT_URL",
         "HEADERS",
         undefined,
+        "CHANGE_SET"
+      )
+    );
+  });
+
+  it(".addRequestWithPayload", function () {
+    sinon.stub(batch, "addRequest").returns("REQUEST");
+    assert.strictEqual(
+      batch.addRequestWithPayload(
+        "HTTP_METHOD",
+        "INPUT_URL",
+        {
+          KEY: "VALUE",
+        },
+        "PAYLOAD",
+        "CHANGE_SET"
+      ),
+      "REQUEST"
+    );
+    assert.ok(
+      batch.addRequest.calledWithExactly(
+        "HTTP_METHOD",
+        "INPUT_URL",
+        {
+          "sap-contextid-accept": "header",
+          Accept: "application/json",
+          DataServiceVersion: "2.0",
+          MaxDataServiceVersion: "2.0",
+          "Content-Type": "application/json",
+          "sap-message-scope": "BusinessObject",
+          KEY: "VALUE",
+        },
+        "PAYLOAD",
         "CHANGE_SET"
       )
     );

--- a/test/unit/engine/QueryableResource.js
+++ b/test/unit/engine/QueryableResource.js
@@ -603,7 +603,7 @@ describe("QueryableResource", function () {
     });
   });
 
-  describe(".merge()", function () {
+  describe(".processUpdateCall()", function () {
     let newData;
     let request;
     beforeEach(() => {
@@ -649,7 +649,7 @@ describe("QueryableResource", function () {
         })
       );
       request._payload = "BODY_PROPERTIES";
-      return entitySet.merge(body).then((res) => {
+      return entitySet.processUpdateCall("merge", body).then((res) => {
         assert.ok(request.payload.calledWithExactly("BODY_PROPERTIES"));
         assert(request.header.calledWith("x-csrf-token", "TOKEN"));
         assert(request.header.calledWith("Content-type", "application/json"));
@@ -674,7 +674,7 @@ describe("QueryableResource", function () {
       entitySet.raw();
       request._payload = "BODY_PROPERTIES";
 
-      return entitySet.merge(body).then((res) => {
+      return entitySet.processUpdateCall("merge", body).then((res) => {
         assert.ok(request.payload.calledWithExactly("BODY_PROPERTIES"));
         assert(request.header.calledWith("x-csrf-token", "TOKEN"));
         assert(request.header.calledWith("Content-type", "application/json"));
@@ -702,7 +702,7 @@ describe("QueryableResource", function () {
         .stub()
         .returns(Promise.reject(new Error("ERROR")));
       request._payload = "BODY_PROPERTIES";
-      return entitySet.merge(body).catch((err) => {
+      return entitySet.processUpdateCall("merge", body).catch((err) => {
         assert.ok(request.payload.calledWithExactly("BODY_PROPERTIES"));
         assert(err instanceof Error);
         assert(request.header.calledWith("x-csrf-token", "TOKEN"));
@@ -815,6 +815,22 @@ describe("QueryableResource", function () {
         innerAgent.batchManager.defaultBatch
       );
     });
+  });
+
+  it(".merge()", function () {
+    sinon.stub(entitySet, "processUpdateCall").returns("PROMISE");
+    assert.strictEqual(entitySet.merge("ARG_1", "ARG_2"), "PROMISE");
+    assert.ok(
+      entitySet.processUpdateCall.calledWith("merge", "ARG_1", "ARG_2")
+    );
+  });
+
+  it(".patch()", function () {
+    sinon.stub(entitySet, "processUpdateCall").returns("PROMISE");
+    assert.strictEqual(entitySet.patch("ARG_1", "ARG_2"), "PROMISE");
+    assert.ok(
+      entitySet.processUpdateCall.calledWith("patch", "ARG_1", "ARG_2")
+    );
   });
 
   describe(".delete()", function () {


### PR DESCRIPTION
Implements possibility to use "PATCH" method
via QueryableResource.patch to update entities
for servers which implements OData protocol
version 3.0 and newer. There is no formal check
for OData protocol version.  Usage of patch for older
version of OData protocol is possible.

Topic: #19