### PR TITLE
[INTERNAL] Add REUSE tool information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OData library
 
+[![REUSE status](https://api.reuse.software/badge/github.com/SAP/odata-library)](https://api.reuse.software/info/github.com/SAP/odata-library)
+
 A NodeJS library to access OData services provided by the Netweaver server.
 
 ## Installation
@@ -44,6 +46,4 @@ Norbert Volf <norbert.volf@sap.com>
 
 ## License
 
-Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
-This file is licensed under the Apache Software License, v. 2 except as noted
-otherwise in [the LICENSE file](LICENSE)
+Copyright (c) 2020-2021 SAP SE or an SAP affiliate company and odata-library contributors. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/SAP/odata-library).


### PR DESCRIPTION
In line with SAP OSPO requirements, this PR adds the REUSE Tool links to the README

**Notes:** 
- Please register the repository with the REUSE Tool to complete the integration (see #45 and #46)
- The .npm* files don't seem to be mentioned in the dep5 file. Please have a look and change the REUSE tool metadata accordingly there. Thanks!

Fixes #44