### PR TITLE
[FIX] Correctly create entity with complex type

### DIFF
--- a/lib/model/aggregate.js
+++ b/lib/model/aggregate.js
@@ -1,0 +1,43 @@
+"use strict";
+
+function copyNonSpecialProperties(target, source) {
+  Object.getOwnPropertyNames(source)
+    .concat(Object.getOwnPropertySymbols(source))
+    .forEach((prop) => {
+      if (
+        !prop.match(
+          /^(?:constructor|prototype|arguments|caller|name|bind|call|apply|toString|length)$/
+        )
+      ) {
+        Object.defineProperty(
+          target,
+          prop,
+          Object.getOwnPropertyDescriptor(source, prop)
+        );
+      }
+    });
+}
+
+function aggregate(BaseClass, ...additionalClasses) {
+  let aggregatedClass = class _Combined extends BaseClass {
+    constructor(...args) {
+      super(...args);
+    }
+  };
+
+  additionalClasses.forEach((classToAggregate) => {
+    copyNonSpecialProperties(
+      aggregatedClass.prototype,
+      classToAggregate.prototype
+    );
+    copyNonSpecialProperties(aggregatedClass, classToAggregate);
+  });
+
+  return aggregatedClass;
+}
+
+aggregate._ = {
+  copyNonSpecialProperties: copyNonSpecialProperties,
+};
+
+module.exports = aggregate;

--- a/lib/model/nw/schema/ComplexType.js
+++ b/lib/model/nw/schema/ComplexType.js
@@ -2,6 +2,8 @@
 
 const _ = require("lodash");
 const AnnotationTarget = require("../../oasis/annotations/AnnotationTarget");
+const SharedComplexType = require("../../schema/ComplexType");
+const aggregate = require("../../aggregate");
 const Property = require("./Property");
 
 /**
@@ -13,7 +15,7 @@ const Property = require("./Property");
  * @class ComplexType
  * @extends {AnnotationTarget}
  */
-class ComplexType extends AnnotationTarget {
+class ComplexType extends aggregate(AnnotationTarget, SharedComplexType) {
   /**
    * Creates an instance of ComplexType.
    * @param {Object} rawMetadata raw metadata object for complex type

--- a/lib/model/oasis/schema/ComplexType.js
+++ b/lib/model/oasis/schema/ComplexType.js
@@ -4,6 +4,8 @@ const _ = require("lodash");
 const AnnotationTarget = require("../annotations/AnnotationTarget");
 const NavigationProperty = require("./NavigationProperty");
 const Property = require("./Property");
+const SharedComplexType = require("../../schema/ComplexType");
+const aggregate = require("../../aggregate");
 
 /**
  * Envelops a complex type.
@@ -13,7 +15,7 @@ const Property = require("./Property");
  * @class ComplexType
  * @extends {AnnotationTarget}
  */
-class ComplexType extends AnnotationTarget {
+class ComplexType extends aggregate(AnnotationTarget, SharedComplexType) {
   /**
    * Creates an instance of ComplexType.
    * @param {Object} rawMetadata raw metadata object for complex type

--- a/lib/model/schema/ComplexType.js
+++ b/lib/model/schema/ComplexType.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const _ = require("lodash");
+
+/**
+ * Shared code for nw/oasis ComplexType classes
+ *
+ * @class ComplexType
+ */
+class ComplexType {
+  formatBody(complexTypeValue) {
+    return this.properties
+      .filter((entityTypeProperty) =>
+        _.has(complexTypeValue, entityTypeProperty.name)
+      )
+      .reduce((acc, entityTypeProperty) => {
+        acc[entityTypeProperty.name] = entityTypeProperty.type.formatBody(
+          complexTypeValue[entityTypeProperty.name]
+        );
+        return acc;
+      }, {});
+  }
+}
+
+module.exports = ComplexType;

--- a/test/unit/model/aggregate.js
+++ b/test/unit/model/aggregate.js
@@ -1,0 +1,64 @@
+"use strict";
+
+const assert = require("assert").strict;
+const aggregate = require("../../../lib/model/aggregate");
+
+class A {
+  constructor() {
+    this.A = 1;
+  }
+  methodA() {}
+}
+
+class B {
+  constructor() {
+    this.B = 1;
+  }
+  methodB() {}
+}
+
+describe("lib/model/aggregate", function () {
+  it("aggregate", function () {
+    class C extends aggregate(A, B) {}
+    let instanceC = new C();
+
+    assert.equal(instanceC.A, 1);
+    assert.equal(instanceC.B, undefined);
+    assert.equal(instanceC.methodA, A.prototype.methodA);
+    assert.equal(instanceC.methodB, B.prototype.methodB);
+  });
+  describe("aggregate._.copyNonSpecialProperties", function () {
+    it("copy properties", function () {
+      let target = {
+        foo: "FOO",
+      };
+      aggregate._.copyNonSpecialProperties(target, {
+        bar: "BAR",
+      });
+      assert.deepEqual(target, {
+        foo: "FOO",
+        bar: "BAR",
+      });
+    });
+    it("ignore special properties", function () {
+      let target = {
+        foo: "FOO",
+      };
+      aggregate._.copyNonSpecialProperties(target, {
+        constructor: "CONSTRUCTOR",
+        prototype: "PROTOTYPE",
+        arguments: "ARGUMENTS",
+        caller: "CALLER",
+        name: "NAME",
+        bind: "BIND",
+        call: "CALL",
+        apply: "APPLY",
+        toString: "TO_STRING",
+        length: "LENGTH",
+      });
+      assert.deepEqual(target, {
+        foo: "FOO",
+      });
+    });
+  });
+});

--- a/test/unit/model/schema/ComplexType.js
+++ b/test/unit/model/schema/ComplexType.js
@@ -1,0 +1,80 @@
+"use strict";
+
+const assert = require("assert").strict;
+const sinon = require("sinon");
+const ComplexType = require("../../../../lib/model/schema/ComplexType");
+
+describe("lib/model/schema/ComplexType", function () {
+  let complexType;
+
+  beforeEach(function () {
+    complexType = new ComplexType();
+  });
+
+  describe("formatBody", function () {
+    it("format content", function () {
+      complexType.properties = [
+        {
+          name: "valueA",
+          type: {
+            formatBody: sinon.stub().returnsArg(0),
+          },
+        },
+        {
+          name: "valueB",
+          type: {
+            formatBody: sinon.stub().returnsArg(0),
+          },
+        },
+      ];
+      assert.deepEqual(
+        complexType.formatBody({
+          valueA: "VALUE_A",
+          valueB: "VALUE_B",
+        }),
+        {
+          valueA: "VALUE_A",
+          valueB: "VALUE_B",
+        }
+      );
+    });
+    it("ignore property which is not defined", function () {
+      complexType.properties = [
+        {
+          name: "valueA",
+          type: {
+            formatBody: sinon.stub().returnsArg(0),
+          },
+        },
+      ];
+      assert.deepEqual(
+        complexType.formatBody({
+          valueA: "VALUE_A",
+          valueB: "VALUE_B",
+        }),
+        {
+          valueA: "VALUE_A",
+        }
+      );
+    });
+    it("formatBody is mandatory for property types", function () {
+      complexType.properties = [
+        {
+          name: "valueA",
+          type: {
+            formatBody: sinon.stub().returnsArg(0),
+          },
+        },
+        {
+          name: "valueB",
+        },
+      ];
+      assert.throws(function () {
+        complexType.formatBody({
+          valueA: "VALUE_A",
+          valueB: "VALUE_B",
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Implement formatBody functions for ComplexTypes.
formatBody recursively formats properties in
POST/PUT/MERGE requests.

Topic: #54