### PR TITLE
[FEATURE] Add $filter to entity set count request

### DIFF
--- a/lib/agent/Agent.js
+++ b/lib/agent/Agent.js
@@ -582,20 +582,9 @@ class Agent {
     } else {
       normalizedBatchResponse = _.chain([])
         .concat(...requestsResponses)
-        .map((response) => {
-          let oDataContent = _.get(
-            response,
-            `body.${this._instanceResultPath}`,
-            null
-          );
-          let oDataContentArray = _.get(
-            response,
-            `body.${this._listResultPath}`
-          );
-          return _.isArray(oDataContentArray)
-            ? oDataContentArray
-            : oDataContent || response;
-        })
+        .map((response) =>
+          response.plain(this._listResultPath, this._instanceResultPath)
+        )
         .value();
     }
 

--- a/lib/agent/batch/Batch.js
+++ b/lib/agent/batch/Batch.js
@@ -4,6 +4,7 @@ const Base = require("./Base");
 const Request = require("./Request");
 const ChangeSet = require("./ChangeSet");
 const _ = require("lodash");
+const responseType = require("../../engine/responseType");
 
 /**
  * Batch class implements OData batch request and response processing
@@ -222,13 +223,24 @@ class Batch extends Base {
    * @param {String} inputUrl relative path in the service
    * @param {Object} headers object which contains headers used for the GET request
    * @param {batch/ChangeSet} changeSet which contains newly created request
+   * @param {Number} useResponseType requested type of response constant defined
+   *        in lib/engine/responseType
    *
    * @returns {batch/Request} instance of batch Request
    *
    * @memberof Agent
    */
-  get(inputUrl, headers, changeSet) {
-    return this.addRequest("GET", inputUrl, headers, undefined, changeSet);
+  get(inputUrl, headers, changeSet, useResponseType) {
+    const batchRequest = this.addRequest(
+      "GET",
+      inputUrl,
+      headers,
+      undefined,
+      changeSet
+    );
+
+    batchRequest.responseType = useResponseType;
+    return batchRequest;
   }
 
   /**
@@ -245,7 +257,10 @@ class Batch extends Base {
    * @memberof Agent
    */
   post(...args) {
-    return this.addRequestWithPayload("POST", ...args);
+    const batchRequest = this.addRequestWithPayload("POST", ...args);
+
+    batchRequest.responseType = responseType.ENTITY;
+    return batchRequest;
   }
 
   /**

--- a/lib/agent/batch/Request.js
+++ b/lib/agent/batch/Request.js
@@ -62,6 +62,8 @@ class Request {
       value: rejectRequest,
       writable: false,
     });
+
+    this.responseType = null;
   }
 
   /**

--- a/lib/agent/batch/Response.js
+++ b/lib/agent/batch/Response.js
@@ -4,6 +4,7 @@ const EventEmitter = require("events");
 const _ = require("lodash");
 const HTTPParser = require("http-parser-js").HTTPParser;
 const parsers = require("../parsers");
+const responseType = require("../../engine/responseType");
 
 /**
  * Response class implements OData particular response
@@ -315,6 +316,35 @@ class Response extends EventEmitter {
       error.response = this;
       this.resolve(error);
     }
+  }
+
+  /**
+   * Read plain OData response as javascript object from
+   * Batch response
+   *
+   * @public
+   *
+   * @param {String} listResultPath path to list result (depends on OData version)
+   * @param {String} instanceResultPath path to entity result (depends on OData version)
+   *
+   * @returns {Array|Object} parsed list or entity
+   *
+   * @memberof agent/batch/Response
+   */
+  plain(listResultPath, instanceResultPath) {
+    let result;
+    switch (this.request.responseType) {
+      case responseType.COUNT:
+        result = parsers.count(_.get(this, "body"));
+        break;
+      case responseType.LIST:
+        result = _.get(this, `body.${listResultPath}`);
+        break;
+      case responseType.ENTITY:
+        result = _.get(this, `body.${instanceResultPath}`, null);
+        break;
+    }
+    return result || this;
   }
 }
 

--- a/lib/agent/parsers.js
+++ b/lib/agent/parsers.js
@@ -121,4 +121,24 @@ parsers["application/vnd.ms-excel"] = parseBinary;
 parsers["application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"] =
   parseBinary;
 
+/**
+ * Parse response from count. Raises error for invalid
+ * number in body
+ *
+ * @param {String} responseText response
+ *
+ * @return {Number} returns
+ *
+ * @memberof QueryableResource
+ */
+parsers.count = function (responseText) {
+  const count = parseInt(responseText, 10);
+
+  if (isNaN(count)) {
+    throw new Error("Backend returns invalid count value.");
+  }
+
+  return count;
+};
+
 module.exports = parsers;

--- a/lib/engine/QueryableResource.js
+++ b/lib/engine/QueryableResource.js
@@ -2,6 +2,8 @@
 
 const _ = require("lodash");
 const Resource = require("./Resource");
+const responseType = require("./responseType");
+const parsers = require("../agent/parsers");
 
 /**
  * Envelope GET/POST/PUT/DELETE methods for particular QueryableResource
@@ -86,62 +88,14 @@ class QueryableResource extends Resource {
   /**
    * Send request to count of the EntitySet
    *
-   * @param {RequestDefinition} request optional request definition (default entity set request is used as default)
+   * @param {RequestDefinition} [request] optional request definition (default entity set request is used as default)
+   *
    * @return {Promise} returned promise is resolved when request is finished
+   *
    * @memberof QueryableResource
    */
   count(request = this.defaultRequest) {
-    this.reset();
-
-    return new Promise((resolve, reject) => {
-      if (!this.entitySetModel.sap.countable) {
-        reject(
-          new Error(
-            `The EntitySet ${this.entitySetModel.name} is not countable.`
-          )
-        );
-      } else {
-        this.agent
-          .get(
-            `/${this.entitySetModel.name}/$count`,
-            request._headers,
-            undefined,
-            true
-          )
-          .then((res) => {
-            let count;
-
-            if (request._isRaw) {
-              resolve(res);
-            } else {
-              count = this.parseCount(res);
-              if (isNaN(count)) {
-                reject(new Error("Backend returns invalid count value."));
-              }
-              resolve(count);
-            }
-          })
-          .catch((err) => {
-            reject(err);
-          });
-      }
-    });
-  }
-
-  /**
-   * Parse response from count with workaround for superagent which returns
-   * invalid parsed body in newer versions
-   *
-   * @param {Response} res SuperAgent response object
-   * @return {Number} returns NaN for invalid number or valid count
-   * @memberof QueryableResource
-   */
-  parseCount(res) {
-    let count = parseInt(_.get(res, "body"), 10);
-    if (isNaN(count)) {
-      count = parseInt(_.get(res, "res.text"), 10);
-    }
-    return count;
+    return request.count();
   }
 
   /**
@@ -388,17 +342,12 @@ class QueryableResource extends Resource {
           return defaultBatch.get(
             request._path,
             request._headers,
-            defaultChangeSet
+            defaultChangeSet,
+            responseType.determine(request, this)
           );
         }, defaultBatch)
       : this._handleAgentCall(
-          () =>
-            this.agent.get(
-              request._path,
-              request._headers,
-              undefined,
-              request._resource.entityTypeModel.hasStream
-            ),
+          () => this.agent.get(request._path, request._headers),
           request
         );
   }
@@ -646,7 +595,7 @@ class QueryableResource extends Resource {
   determineRequestHeaders(request) {
     let hasStream = request._resource.entityTypeModel.hasStream;
 
-    if (!hasStream) {
+    if (!hasStream && !request._isCount) {
       request.header("Accept", "application/json");
     }
   }
@@ -675,6 +624,8 @@ class QueryableResource extends Resource {
       });
     } else if (response.status === 204) {
       promise = Promise.resolve(null);
+    } else if (request._isCount === true) {
+      promise = response.text().then((text) => parsers.count(text));
     } else {
       promise = response.json().then((json) => {
         resultPath = this.agent.getResultPath(request._isList, json);

--- a/lib/engine/RequestDefinition.js
+++ b/lib/engine/RequestDefinition.js
@@ -4,6 +4,7 @@ const _ = require("lodash");
 const urlUtils = require("../agent/url");
 const Filter = require("./entitySet/Filter");
 const Sorter = require("./entitySet/Sorter");
+const responseType = require("./responseType");
 
 /**
  * Check validity of the key property
@@ -62,10 +63,20 @@ class RequestDefinition {
    * Send request to count of the EntitySet
    *
    * @return {Promise} returned promise is resolved when request is finished
+   *
    * @memberof QueryableResource
    */
   count() {
-    return this._resource.count(this);
+    if (!this._resource.entitySetModel.sap.countable) {
+      throw new Error(
+        `The EntitySet ${this._resource.entitySetModel.name} is not countable.`
+      );
+    }
+
+    this._isCount = true;
+    this.calculatePath();
+
+    return this._resource.executeGet(this);
   }
 
   /**
@@ -465,26 +476,36 @@ class RequestDefinition {
 
   /**
    * Caculate path for GET request.
+   *
    * @private
+   *
    * @memberof RequestDefinition
    */
   calculatePath() {
-    if (this._isList) {
-      let urlQuery = this._resource.urlQuery({
-        $top: 100,
-        $skip: 0,
-        $format: "json",
-      });
-      this._path = `/${this._resource.getListResourcePath()}?${urlQuery}`;
-    } else if (this._resource.entityTypeModel.hasStream && this._isEntity) {
-      this._path = `/${this._resource.getSingleResourcePath()}/\$value`;
-    } else if (this._resource.entityTypeModel.hasStream) {
-      this._path = `/${this._resource.getListResourcePath()}/\$value`;
-    } else {
-      let urlQuery = this._resource.urlQuery({
-        $format: "json",
-      });
-      this._path = `/${this._resource.getSingleResourcePath()}?${urlQuery}`;
+    let urlQuery;
+    switch (responseType.determine(this, this._resource)) {
+      case responseType.COUNT:
+        this._path = `/${this._resource.getListResourcePath()}/\$count?${this._resource.urlQuery()}`;
+        break;
+      case responseType.LIST:
+        urlQuery = this._resource.urlQuery({
+          $top: 100,
+          $skip: 0,
+          $format: "json",
+        });
+        this._path = `/${this._resource.getListResourcePath()}?${urlQuery}`;
+        break;
+      case responseType.ENTITY_STREAM:
+        this._path = `/${this._resource.getSingleResourcePath()}/\$value`;
+        break;
+      case responseType.LIST_STREAM:
+        this._path = `/${this._resource.getListResourcePath()}/\$value`;
+        break;
+      default:
+        urlQuery = this._resource.urlQuery({
+          $format: "json",
+        });
+        this._path = `/${this._resource.getSingleResourcePath()}?${urlQuery}`;
     }
   }
 

--- a/lib/engine/responseType.js
+++ b/lib/engine/responseType.js
@@ -1,0 +1,56 @@
+"use strict";
+
+const _ = require("lodash");
+const TYPE = {
+  COUNT: 1,
+  LIST: 2,
+  ENTITY: 3,
+  LIST_STREAM: 4,
+  ENTITY_STREAM: 5,
+};
+
+exports.COUNT = TYPE.COUNT;
+exports.LIST = TYPE.LIST;
+exports.ENTITY = TYPE.ENTITY;
+exports.LIST_STREAM = TYPE.LIST_STREAM;
+exports.ENTITY_STREAM = TYPE.ENTITY_STREAM;
+
+exports.probes = {};
+
+exports.probes[TYPE.COUNT] = function (request) {
+  return _.get(request, "_isCount") === true;
+};
+
+exports.probes[TYPE.LIST] = function (request, resource) {
+  return (
+    Boolean(_.get(request, "_isList")) &&
+    !_.get(resource, "entityTypeModel.hasStream")
+  );
+};
+
+exports.probes[TYPE.ENTITY] = function (request, resource) {
+  return (
+    Boolean(_.get(request, "_isEntity")) &&
+    !_.get(resource, "entityTypeModel.hasStream")
+  );
+};
+
+exports.probes[TYPE.LIST_STREAM] = function (request, resource) {
+  return (
+    !_.get(request, "_isEntity") &&
+    Boolean(_.get(resource, "entityTypeModel.hasStream"))
+  );
+};
+
+exports.probes[TYPE.ENTITY_STREAM] = function (request, resource) {
+  return (
+    Boolean(_.get(request, "_isEntity")) &&
+    Boolean(_.get(resource, "entityTypeModel.hasStream"))
+  );
+};
+
+exports.determine = function (request, resource) {
+  return _.find(TYPE, (value, key) =>
+    exports.probes[TYPE[key]](request, resource)
+  );
+};

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "validate": "npm run validate:eslint && npm run validate:prettier && npm run validate:test",
     "validate:prettier": "prettier --check \"lib/**/*.js\" \"test/**/*.js\"",
     "validate:eslint": "eslint \"lib/**/*.js\" \"test/**/*.js\"",
-    "validate:test": "mocha -R progress ./test/unit/**/*.js ./test/func/**/*.js",
+    "validate:test": "mocha -R progress --recursive ./test/unit/ ./test/func/",
     "watch": "nodemon -e js,xml -x \"npm run validate\""
   },
   "repository": {

--- a/test/unit/agent/Agent.js
+++ b/test/unit/agent/Agent.js
@@ -780,26 +780,31 @@ describe("lib/engine/Agent", function () {
   describe(".normalizeBatchResponse", function () {
     it("Returns parsed particular OData responses.", function () {
       agent.setServiceVersion("1.0");
+      const response1 = {
+        plain: sinon.stub().returns([]),
+      };
+      const response2 = {
+        plain: sinon.stub().returns({}),
+      };
       assert.deepEqual(
         agent.normalizeBatchResponse(
           "BATCH_RESPONSE",
-          [
-            {
-              body: {
-                d: {
-                  results: [],
-                },
-              },
-            },
-            {
-              body: {
-                d: {},
-              },
-            },
-          ],
+          [response1, response2],
           false
         ),
         [[], {}]
+      );
+      assert.ok(
+        response1.plain.calledWithExactly(
+          agent._listResultPath,
+          agent._instanceResultPath
+        )
+      );
+      assert.ok(
+        response2.plain.calledWithExactly(
+          agent._listResultPath,
+          agent._instanceResultPath
+        )
       );
     });
     it("Returns batch responses with full particular responses.", function () {
@@ -809,32 +814,6 @@ describe("lib/engine/Agent", function () {
         {
           batchResponses: ["RESPONSE_1", "RESPONSE_2"],
         }
-      );
-    });
-    it("Returns parsed OData responses in changeSet.", function () {
-      agent.setServiceVersion("1.0");
-      assert.deepEqual(
-        agent.normalizeBatchResponse(
-          "BATCH_RESPONSE",
-          [
-            [
-              {
-                body: {
-                  d: {
-                    results: [],
-                  },
-                },
-              },
-              {
-                body: {
-                  d: {},
-                },
-              },
-            ],
-          ],
-          false
-        ),
-        [[], {}]
       );
     });
   });

--- a/test/unit/agent/batch/Request.js
+++ b/test/unit/agent/batch/Request.js
@@ -28,6 +28,7 @@ describe("agent/batch/Batch", function () {
       Header: "header-value",
     });
     assert.strictEqual(request.content, "PAYLOAD");
+    assert.strictEqual(request.responseType, null);
   });
 
   describe(".payload", function () {

--- a/test/unit/agent/batch/Response.js
+++ b/test/unit/agent/batch/Response.js
@@ -4,6 +4,7 @@ const assert = require("assert");
 const sinon = require("sinon");
 const proxyquire = require("proxyquire");
 const _ = require("lodash");
+const responseType = require("../../../../lib/engine/responseType");
 
 describe("agent/batch/Response", function () {
   let response;
@@ -367,5 +368,27 @@ describe("agent/batch/Response", function () {
       HEADER_KEY_1: "HEADER_VALUE_1",
       HEADER_KEY_2: "HEADER_VALUE_2",
     });
+  });
+
+  it(".plain", function () {
+    response.request = {
+      responseType: responseType.ENTITY,
+    };
+    response.body = {
+      d: {},
+    };
+    assert.deepEqual(response.plain("d.results", "d"), {});
+    response.request = {
+      responseType: responseType.LIST,
+    };
+    response.body = {
+      d: { results: [] },
+    };
+    assert.deepEqual(response.plain("d.results", "d"), []);
+    response.request = {
+      responseType: responseType.COUNT,
+    };
+    response.body = "5";
+    assert.deepEqual(response.plain("d.results", "d"), 5);
   });
 });

--- a/test/unit/agent/parsers.js
+++ b/test/unit/agent/parsers.js
@@ -152,4 +152,12 @@ describe("parsers", function () {
       );
     });
   });
+
+  it(".count()", function () {
+    assert.strictEqual(parsers.count("10"), 10);
+    assert.strictEqual(parsers.count(10), 10);
+    assert.throws(() => {
+      parsers.count(null);
+    });
+  });
 });

--- a/test/unit/engine/RequestDefinition.js
+++ b/test/unit/engine/RequestDefinition.js
@@ -55,9 +55,29 @@ describe("RequestDefinition", function () {
   });
 
   describe(".count()", function () {
-    it("calls entity set count", function () {
-      request.count();
-      assert.ok(entitySet.count.calledWith(request));
+    it("try run count on non-countable entity set", function () {
+      request._resource.entitySetModel = {
+        sap: {
+          countable: false,
+        },
+      };
+      assert.throws(() => {
+        request.count();
+      });
+    });
+    it("try run count on non-countable entity set", function () {
+      request._resource.entitySetModel = {
+        sap: {
+          countable: true,
+        },
+      };
+      request._resource.executeGet = sinon.stub().returns(Promise.resolve());
+      sinon.stub(request, "calculatePath");
+      return request.count().then(() => {
+        assert.equal(request._isCount, true);
+        assert.ok(request.calculatePath.called);
+        assert.ok(request._resource.executeGet.calledWithExactly(request));
+      });
     });
   });
 
@@ -245,7 +265,7 @@ describe("RequestDefinition", function () {
       sinon.stub(request, "_isList").get(function () {
         return true;
       });
-      request._resource.entityTypeModel.hasStream = true;
+      request._resource.entityTypeModel.hasStream = false;
       sinon.stub(request._resource, "urlQuery").returns("QUERY");
       request.calculatePath();
       assert.strictEqual(request._path, "/path?QUERY");

--- a/test/unit/engine/responseType.js
+++ b/test/unit/engine/responseType.js
@@ -1,0 +1,64 @@
+"use strict";
+
+const assert = require("assert").strict;
+const responseType = require("../../../lib/engine/responseType");
+
+describe("engine/responseType", function () {
+  it("#determine()", function () {
+    assert.equal(
+      responseType.determine({
+        _isCount: true,
+      }),
+      responseType.COUNT
+    );
+    assert.equal(
+      responseType.determine(
+        {
+          _isList: true,
+        },
+        {
+          entityTypeModel: {},
+        }
+      ),
+      responseType.LIST
+    );
+    assert.equal(
+      responseType.determine(
+        {
+          _isEntity: true,
+        },
+        {
+          entityTypeModel: {},
+        }
+      ),
+      responseType.ENTITY
+    );
+    assert.equal(
+      responseType.determine(
+        {
+          _isList: true,
+        },
+        {
+          entityTypeModel: {
+            hasStream: true,
+          },
+        }
+      ),
+      responseType.LIST_STREAM
+    );
+    assert.equal(
+      responseType.determine(
+        {
+          _isEntity: true,
+        },
+        {
+          entityTypeModel: {
+            hasStream: true,
+          },
+        }
+      ),
+      responseType.ENTITY_STREAM
+    );
+    assert.equal(responseType.determine(), undefined);
+  });
+});


### PR DESCRIPTION
Count had separated implementation to generate
HTTP requests.  The patch uses executeGet method
to run count request instead of separated code.

Topic: #62