### PR TITLE
Resolve properties from navigation properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 1.0.1
+
+- c660f58 - [FEATURE] Resolve deep property - Norbert Volf
+- daee07d - [FEATURE] Add $filter to entity set count request - Norbert Volf
+
 # 1.0.0
 
 - d859989 - [FIX] Raise error for error status codes - Norbert Volf

--- a/lib/engine/QueryableResource.js
+++ b/lib/engine/QueryableResource.js
@@ -502,7 +502,6 @@ class QueryableResource extends Resource {
     entityTypeModelStart
   ) {
     let assoociationEnd = entityTypeModelStart.navigationPropertyAssociationTo(
-      this.metadata.model,
       navigationProperty.name
     );
     let entityTypeModelEnd = _.get(assoociationEnd, "type");

--- a/lib/model/nw/CsdlSchema.js
+++ b/lib/model/nw/CsdlSchema.js
@@ -37,7 +37,7 @@ const childCollections = [
 function initChildProperties(schema) {
   childCollections.forEach((collection) => {
     let child = _.get(schema.raw, collection.sourceElement, []).map(
-      (t) => new collection.Class(t)
+      (t) => new collection.Class(t, schema.model)
     );
     Object.defineProperty(schema, collection.name, {
       get: () => child,
@@ -106,11 +106,14 @@ function parseModelPath(targetPath) {
 class CsdlSchema {
   /**
    * Creates an instance of CsdlSchema.
+   *
    * @param {Object} rawMetadata raw metadata object for schema
    * @param {Object} [settings] (normalized) settings for the metadata, e.g. { strict: false } to ignore non critical errors
+   * @param {Object} model reference to model which owns the schema
+   *
    * @memberof CsdlSchema
    */
-  constructor(rawMetadata, settings) {
+  constructor(rawMetadata, settings, model) {
     Object.defineProperty(this, "raw", {
       get: () => rawMetadata,
     });
@@ -130,6 +133,10 @@ class CsdlSchema {
 
     Object.defineProperty(this, "settings", {
       get: () => settings,
+    });
+
+    Object.defineProperty(this, "model", {
+      get: () => model,
     });
 
     initChildProperties(this);

--- a/lib/model/nw/schema/ComplexType.js
+++ b/lib/model/nw/schema/ComplexType.js
@@ -18,11 +18,14 @@ const Property = require("./Property");
 class ComplexType extends aggregate(AnnotationTarget, SharedComplexType) {
   /**
    * Creates an instance of ComplexType.
+   *
    * @param {Object} rawMetadata raw metadata object for complex type
+   * @param {Object} model reference to model which owns the schema
+   *
    * @memberof ComplexType
    */
-  constructor(rawMetadata) {
-    super(rawMetadata);
+  constructor(rawMetadata, model) {
+    super(rawMetadata, model);
     let properties = _.get(this.raw, "Property", []).map(
       (p) => new Property(p)
     );
@@ -57,12 +60,34 @@ class ComplexType extends aggregate(AnnotationTarget, SharedComplexType) {
    * @memberof ComplexType
    */
   getProperty(name) {
-    let prop = this.properties.find((p) => p.name === name);
-    if (!prop) {
+    let property;
+    let properties;
+
+    const propertyNameParts = name.split("/");
+    const propertyName = propertyNameParts[propertyNameParts.length - 1];
+    const navigationPropertyName = propertyNameParts[0];
+
+    if (propertyNameParts.length === 1) {
+      properties = this.properties;
+    } else {
+      properties = _.chain(this.navigationProperties)
+        .filter((np) => navigationPropertyName === np.name)
+        .map((navigationProperty) => {
+          const associationEnd = this.model.resolveModelPath(
+            navigationProperty.relationship
+          );
+          return _.get(associationEnd, "ends.1.type.properties", []);
+        })
+        .get(0, [])
+        .value();
+    }
+    property = properties.find((p) => p.name === propertyName);
+
+    if (!property) {
       throw new Error(`Property '${name}' not found in type ${this.name}.`);
     }
 
-    return prop;
+    return property;
   }
 
   /**

--- a/lib/model/nw/schema/EntityType.js
+++ b/lib/model/nw/schema/EntityType.js
@@ -16,11 +16,14 @@ const NavigationProperty = require("./NavigationProperty");
 class EntityType extends ComplexType {
   /**
    * Creates an instance of EntityType.
+   *
    * @param {Object} rawMetadata raw metadata object for complex type
+   * @param {Object} model reference to model which owns the entity type
+   *
    * @memberof EntityType
    */
-  constructor(rawMetadata) {
-    super(rawMetadata);
+  constructor(rawMetadata, model) {
+    super(rawMetadata, model);
 
     let key = this._createKey();
     Object.defineProperty(this, "key", {

--- a/lib/model/nw/schema/EntityType.js
+++ b/lib/model/nw/schema/EntityType.js
@@ -150,7 +150,6 @@ class EntityType extends ComplexType {
   /**
    * Find association
    *
-   * @param {EdmxModel} metaModel which contains all metadata informations
    * @param {String} navigationPropertyName name of the navigation property
    *
    * @returns {AssociationEnd}  association endpoint to the navigation property  entity type
@@ -159,7 +158,7 @@ class EntityType extends ComplexType {
    *
    * @private
    */
-  navigationPropertyAssociationTo(metaModel, navigationPropertyName) {
+  navigationPropertyAssociationTo(navigationPropertyName) {
     let association;
     let associationEnd;
     let navigationPropertyDefinition = _.find(
@@ -173,7 +172,7 @@ class EntityType extends ComplexType {
       );
     }
 
-    association = metaModel.resolveModelPath(
+    association = this.model.resolveModelPath(
       navigationPropertyDefinition.relationship
     );
 

--- a/lib/model/oasis/annotations/AnnotationTarget.js
+++ b/lib/model/oasis/annotations/AnnotationTarget.js
@@ -12,10 +12,13 @@ const ExpressionBuilder = require("./ExpressionBuilder");
 class AnnotationTarget {
   /**
    * Creates an instance of AnnotationTarget.
+   *
    * @param {Object} rawMetadata raw metadata object for annotation target object
+   * @param {Object} model reference to model which owns the annotation target
+   *
    * @memberof AnnotationTarget
    */
-  constructor(rawMetadata) {
+  constructor(rawMetadata, model) {
     this.annotations = [];
 
     // almost all annotation target types must have uniquie name (in some scope)
@@ -33,6 +36,10 @@ class AnnotationTarget {
     let extensions = [];
     Object.defineProperty(this, "extensions", {
       get: () => extensions,
+    });
+
+    Object.defineProperty(this, "model", {
+      get: () => model,
     });
   }
 

--- a/lib/model/oasis/schema/ComplexType.js
+++ b/lib/model/oasis/schema/ComplexType.js
@@ -30,12 +30,9 @@ class ComplexType extends aggregate(AnnotationTarget, SharedComplexType) {
       get: () => properties,
     });
 
-    let navigationProperties = _.get(this.raw, "NavigationProperty", []).map(
+    this.navigationProperties = _.get(this.raw, "NavigationProperty", []).map(
       (p) => new NavigationProperty(p)
     );
-    Object.defineProperty(this, "navigationProperties", {
-      get: () => navigationProperties,
-    });
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sap_oss/odata-library",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OData client for testing Netweawer OData services.",
   "main": "index.js",
   "dependencies": {

--- a/test/unit/engine/QueryableResource.js
+++ b/test/unit/engine/QueryableResource.js
@@ -1079,7 +1079,6 @@ describe("QueryableResource", function () {
       }, /End EntityType/);
       assert.ok(
         entityTypeModel.navigationPropertyAssociationTo.calledWith(
-          "MODEL",
           "navPropKey1"
         )
       );
@@ -1122,7 +1121,6 @@ describe("QueryableResource", function () {
       );
       assert.ok(
         entityTypeModel.navigationPropertyAssociationTo.calledWith(
-          "MODEL",
           "navPropKey1"
         )
       );
@@ -1184,8 +1182,7 @@ describe("QueryableResource", function () {
         }
       );
       assert.ok(
-        entityTypeModel.navigationPropertyAssociationTo.calledWith(
-          "MODEL",
+        entityTypeModel.navigationPropertyAssociationTo.calledWithExactly(
           "navPropKey1"
         )
       );

--- a/test/unit/model/nw/CsdlSchema.js
+++ b/test/unit/model/nw/CsdlSchema.js
@@ -79,7 +79,7 @@ const sampleSchemaMD = {
 describe("CsdlSchema", function () {
   describe("#constructor()", function () {
     it("initializes properties", function () {
-      let schema = new CsdlSchema(emptySchemaMD, settings);
+      let schema = new CsdlSchema(emptySchemaMD, settings, "MODEL");
       assert.strictEqual(schema.raw, emptySchemaMD);
       assert.deepEqual(schema.namespace, "ns");
       assert.equal(schema.settings, settings);
@@ -88,6 +88,7 @@ describe("CsdlSchema", function () {
       assert.ok(_.isArray(schema.entityTypes));
       assert.ok(_.isArray(schema.entityContainers));
       assert.ok(_.isArray(schema.extensions));
+      assert.strictEqual(schema.model, "MODEL");
     });
 
     it("applies annotations", function () {

--- a/test/unit/model/nw/schema/ComplexType.js
+++ b/test/unit/model/nw/schema/ComplexType.js
@@ -2,6 +2,7 @@
 
 const _ = require("lodash");
 const assert = require("assert");
+const sinon = require("sinon");
 const ComplexType = require("../../../../../lib/model/nw/schema/ComplexType");
 const sampleComplexTypeMD = {
   $: {
@@ -25,9 +26,15 @@ const schema = {
 };
 
 describe("ComplexType (nw)", function () {
+  let model;
+  let type;
+  beforeEach(function () {
+    model = {};
+    type = new ComplexType(sampleComplexTypeMD, model);
+  });
+
   describe("#constructor()", function () {
     it("initializes properties", function () {
-      let type = new ComplexType(sampleComplexTypeMD);
       assert.equal(type.raw, sampleComplexTypeMD);
       assert.equal(type.name, "ComplexType1");
       assert.ok(_.isArray(type.properties));
@@ -36,7 +43,6 @@ describe("ComplexType (nw)", function () {
 
   describe(".initSchemaDependentProperties()", function () {
     it("initializes namespaceQualifiedName and properties", function () {
-      let type = new ComplexType(sampleComplexTypeMD);
       type.initSchemaDependentProperties(schema);
       assert.equal(type.namespaceQualifiedName, "ns.ComplexType1");
       assert.equal(
@@ -48,33 +54,85 @@ describe("ComplexType (nw)", function () {
 
   describe(".getProperty()", function () {
     it("gets property by its name", function () {
-      let type = new ComplexType(sampleComplexTypeMD);
       let prop = type.getProperty("Prop1");
       assert.ok(prop);
       assert.equal(prop.name, "Prop1");
     });
 
     it("throw error when property is not available", function () {
-      let type = new ComplexType(sampleComplexTypeMD);
       assert.throws(() => type.getProperty("noProp"));
+    });
+
+    it("get property from navigation property of the entityType", function () {
+      model.resolveModelPath = sinon.stub().returns({
+        ends: [
+          "FROM",
+          {
+            type: {
+              properties: [
+                {
+                  name: "propertyInNP",
+                },
+              ],
+            },
+          },
+        ],
+      });
+      type.navigationProperties = [
+        {
+          name: "toNavigationProperty",
+          relationship: "RELATIONSHIP",
+        },
+      ];
+      assert.deepEqual(type.getProperty("toNavigationProperty/propertyInNP"), {
+        name: "propertyInNP",
+      });
+      assert.ok(model.resolveModelPath.calledWithExactly("RELATIONSHIP"));
+    });
+
+    it("missing property in the entityType navigation property", function () {
+      model.resolveModelPath = sinon.stub().returns({
+        ends: [
+          "FROM",
+          {
+            type: {
+              properties: [
+                {
+                  name: "propertyInNP",
+                },
+              ],
+            },
+          },
+        ],
+      });
+      type.navigationProperties = [
+        {
+          name: "toNavigationProperty",
+          relationship: "RELATIONSHIP",
+        },
+      ];
+      assert.throws(() => {
+        type.getProperty("toNavigationProperty/missingPropertyInNP");
+      });
+      assert.ok(model.resolveModelPath.calledWithExactly("RELATIONSHIP"));
     });
   });
 
   describe(".resolveModelPath()", function () {
     it("resolves itself", function () {
-      let type = new ComplexType(sampleComplexTypeMD);
+      type = new ComplexType(sampleComplexTypeMD);
       assert.deepEqual(type.resolveModelPath(), type);
     });
 
     it("resolves properties", function () {
-      let type = new ComplexType(sampleComplexTypeMD);
+      type = new ComplexType(sampleComplexTypeMD);
       assert.equal(type.resolveModelPath("Prop1").name, "Prop1");
     });
   });
 
   describe(".getLegacyApiObject()", function () {
     it("implements annotations api", function () {
-      let type = new ComplexType(sampleComplexTypeMD);
+      type = new ComplexType(sampleComplexTypeMD);
       type.initSchemaDependentProperties(schema);
       let api = type.getLegacyApiObject();
       assert.equal(api.Name, "ComplexType1");

--- a/test/unit/model/nw/schema/EntityType.js
+++ b/test/unit/model/nw/schema/EntityType.js
@@ -88,8 +88,11 @@ function createSchema(type) {
 
 describe("EntityType (nw)", function () {
   let type;
+  let model;
+
   beforeEach(function () {
-    type = new EntityType(sampleEntityTypeMD, "MODEL");
+    model = {};
+    type = new EntityType(sampleEntityTypeMD, model);
   });
 
   describe("#constructor()", function () {
@@ -99,7 +102,7 @@ describe("EntityType (nw)", function () {
       assert.ok(_.isArray(type.properties));
       assert.ok(_.isArray(type.navigationProperties));
       assert.ok(_.isArray(type.key));
-      assert.equal(type.model, "MODEL");
+      assert.equal(type.model, model);
     });
 
     it("creates key", function () {
@@ -192,42 +195,30 @@ describe("EntityType (nw)", function () {
   describe(".navigationPropertyAssociationTo()", function () {
     it("Missing navigation property raises error.", function () {
       assert.throws(() => {
-        type.navigationPropertyAssociationTo("METAMODEL", "NavPropMissing");
+        type.navigationPropertyAssociationTo("NavPropMissing");
       }, /Navigation property/);
     });
     it("Missing association raises error.", function () {
+      model.resolveModelPath = sinon.stub();
       assert.throws(() => {
-        type.navigationPropertyAssociationTo(
-          {
-            resolveModelPath: sinon.stub(),
-          },
-          "NavProp1"
-        );
+        type.navigationPropertyAssociationTo("NavProp1");
       }, /Association for/);
     });
     it("Missing association end raises error.", function () {
+      model.resolveModelPath = sinon.stub().returns({
+        findEnd: sinon.stub(),
+      });
       assert.throws(() => {
-        type.navigationPropertyAssociationTo(
-          {
-            resolveModelPath: sinon.stub().returns({
-              findEnd: sinon.stub(),
-            }),
-          },
-          "NavProp1"
-        );
+        type.navigationPropertyAssociationTo("NavProp1");
       }, /Association endpoint/);
     });
 
     it("Association end found.", function () {
+      model.resolveModelPath = sinon.stub().returns({
+        findEnd: sinon.stub().returns("ASSOCIATION_END"),
+      });
       assert.strictEqual(
-        type.navigationPropertyAssociationTo(
-          {
-            resolveModelPath: sinon.stub().returns({
-              findEnd: sinon.stub().returns("ASSOCIATION_END"),
-            }),
-          },
-          "NavProp1"
-        ),
+        type.navigationPropertyAssociationTo("NavProp1"),
         "ASSOCIATION_END"
       );
     });

--- a/test/unit/model/nw/schema/EntityType.js
+++ b/test/unit/model/nw/schema/EntityType.js
@@ -89,7 +89,7 @@ function createSchema(type) {
 describe("EntityType (nw)", function () {
   let type;
   beforeEach(function () {
-    type = new EntityType(sampleEntityTypeMD);
+    type = new EntityType(sampleEntityTypeMD, "MODEL");
   });
 
   describe("#constructor()", function () {
@@ -99,6 +99,7 @@ describe("EntityType (nw)", function () {
       assert.ok(_.isArray(type.properties));
       assert.ok(_.isArray(type.navigationProperties));
       assert.ok(_.isArray(type.key));
+      assert.equal(type.model, "MODEL");
     });
 
     it("creates key", function () {

--- a/test/unit/model/oasis/annotations/AnnotationTarget.js
+++ b/test/unit/model/oasis/annotations/AnnotationTarget.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const _ = require("lodash");
-const assert = require("assert");
+const assert = require("assert").strict;
 const AnnotationTarget = require("../../../../../lib/model/oasis/annotations/AnnotationTarget");
 
 function applyAnnotationsToTarget() {
@@ -41,11 +41,12 @@ describe("AnnotationTarget", function () {
         },
       };
 
-      let target = new AnnotationTarget(md);
+      let target = new AnnotationTarget(md, "MODEL");
 
       assert.equal(target.name, "name");
       assert.equal(target.raw, md);
       assert.ok(_.isArray(target.annotations));
+      assert.equal(target.model, "MODEL");
     });
 
     it("allows empty name", function () {


### PR DESCRIPTION
Add possibility to resolve properties from EntityType in metadata which is defined by path to NavigationProperty. The patch resolves the issue  #66