### PR TITLE
feature/master/#72/Authorize via cookie header

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -27,7 +27,7 @@ Promise.all([
     if (matchCurrentBranch && !commitMessage.match(/^\[/)) {
       topic = matchCurrentBranch[2].trim();
       type = matchCurrentBranch[1].trim();
-      type = type.charAt(0).toUpperCase() + type.slice(1);
+      type = type.toUpperCase();
 
       commitMessage = `[${type}] ${commitMessage}\n\n\nTopic: ${topic}`;
       messageUpdated = true;

--- a/doc/INITIALIZE.md
+++ b/doc/INITIALIZE.md
@@ -5,7 +5,7 @@
 You can pass url with (or without) authorization in one string in the code.
 
 ```javascript
-var service = new Service(
+const service = new Service(
   "https://username:password@localhost/path/to/service/"
 );
 
@@ -28,7 +28,7 @@ export ODATA_CA_CERT_PATH="/etc/ssl/certificates/root.crt"
 ```
 
 ```javascript
-var service = new Service();
+const service = new Service();
 
 service.init.then(() => {
   //Code
@@ -43,11 +43,10 @@ definitons in the environment variables.
 
 ```shell
 export NODE_EXTRA_CA_CERTS=/etc/ssl/certificates/root.crt
-
 ```
 
 ```javascript
-var service = new Service({
+const service = new Service({
   url: "https://localhost/service/",
   annotationsUrl: "https://localhost/serviceMetadata/annotations",
   auth: {
@@ -66,6 +65,57 @@ var service = new Service({
 service.init.then(() => {
   //Code
 });
+```
+
+## Authenticate to service outside of Service
+
+Handle authorization process outside of the odata-library and pass authorization cookie
+to odata-library service.
+
+Set cookie via environment variable
+
+```shell
+export ODATA_COOKIE="JSESSIONID=s:bdzps02ARlShtevVcSWsTLptzhPdAF-y.r2nlOcl38jriMxfIhcvIzyFwS0V9nITPUz8orkAHMic"
+```
+
+More than one cookie by JSON string
+
+```shell
+export ODATA_COOKIE='["JSESSIONID=s:bdzps02ARlShtevVcSWsTLptzhPdAF-y.r2nlOcl38jriMxfIhcvIzyFwS0V9nITPUz8orkAHMic", "language=cz"]'
+```
+
+Set cookie via constructor
+
+```javascript
+const service = new Service({
+  url: "https://localhost/service/",
+  auth: {
+    cookies: [
+      "JSESSIONID=s:bdzps02ARlShtevVcSWsTLptzhPdAF-y.r2nlOcl38jriMxfIhcvIzyFwS0V9nITPUz8orkAHMic",
+      "language=cz",
+    ],
+  },
+  parameters: {
+    //Define initial request by $metadata?sap-client=902&sap-documentation=&sap-language=EN
+    "sap-client": "902",
+    "sap-documentation": ["heading", "quickinfo"],
+    "sap-language": "EN",
+  },
+  strict: false, // ignore non critical errors, e.g. orphaned annotations
+});
+
+service.init.then(() => {
+  //Code
+});
+```
+
+Do not forgot to decode encoded cookie header which is taken from request/response header
+in browser development tools
+
+```javascript
+decodeURIComponent(
+  "JSESSIONID=s%3Abdzps02ARlShtevVcSWsTLptzhPdAF-y.r2nlOcl38jriMxfIhcvIzyFwS0V9nITPUz8orkAHMic"
+);
 ```
 
 ## TLS/SSL server certificate

--- a/lib/agent/Agent.js
+++ b/lib/agent/Agent.js
@@ -7,6 +7,7 @@ const log = require("./log");
 const xml2js = require("xml2js");
 const nodeFetch = require("node-fetch");
 const tough = require("tough-cookie");
+const authentication = require("./authentication");
 
 const AUTH_HEADERS = Symbol("AUTH_HEADERS");
 const CSRF_TOKEN = Symbol("CSRF_TOKEN");
@@ -53,14 +54,6 @@ class Agent {
       value: new tough.CookieJar(),
       writable: false,
     });
-  }
-
-  static get authenticators() {
-    return [
-      "./authentication/samlSap",
-      "./authentication/basic",
-      "./authentication/none",
-    ];
   }
 
   /**
@@ -149,7 +142,7 @@ class Agent {
         : []
     );
 
-    return this.authenticate(metadataUrls[0]).then(() => {
+    return authentication.authenticate(this, metadataUrls[0]).then(() => {
       return Promise.all(
         _.map(metadataUrls, (requestUrl) =>
           this.createMetadataRequest(requestUrl)
@@ -413,150 +406,6 @@ class Agent {
       });
     }
     return promise;
-  }
-
-  /**
-   * Authenticate user by authenticators. Authenticators are modules
-   * in lib/agent/authentication/. List of modules is in Agent.authenticators
-   * array. Authenticate method calls authenticators in order of list.
-   * User is authenticated when first authenticator succeed.
-   *
-   * @param {String} endpointUrl url of metadata, which is used as
-   *        root of service
-   *
-   * @return {Promise} promise which is resolve when first authenticator succeed
-   *        or reject if all authenticators fails
-   *
-   * @memberof Agent
-   */
-  authenticate(endpointUrl) {
-    return new Promise((resolve, reject) => {
-      let authenticator;
-      if (_.isArray(Agent.authenticators) && Agent.authenticators.length > 0) {
-        authenticator = require(Agent.authenticators[0]);
-        this.logger.debug(
-          `Try to authenticate over ${authenticator.authenticatorName} authenticator.`
-        );
-        this.tryAuthenticator(
-          1,
-          endpointUrl,
-          authenticator(this.settings, this, endpointUrl),
-          resolve,
-          reject
-        );
-      } else {
-        reject(new Error("Authenticators are not defined."));
-      }
-    });
-  }
-
-  /**
-   * Try authenticate user by particular authenticator. If authenticator
-   * fails try to use next authenticator from Agent.authenticators list.
-   * If all authenticators fails call callBackError parameter if any
-   * authenticator succeed call callBack parameter
-   *
-   * The method is used internally in the public authenticated method
-   *
-   * @private
-   *
-   * @param {Number} index to the Agent.authenticators which is used
-   * @param {String} endpointUrl url of metadata, which is used as
-   *        root of service
-   * @param {Promise} previousAuthenticatorPromise determine previous
-   *        authenticator result
-   * @param {Function} callBack called when authenticator succeed
-   * @param {Promise} callBackError called when all authenticators
-   *        fails
-   *
-   * @memberof Agent
-   */
-  tryAuthenticator(
-    index,
-    endpointUrl,
-    previousAuthenticatorPromise,
-    callBack,
-    callBackError
-  ) {
-    let previousAuthenticator;
-    let authenticator;
-
-    previousAuthenticator = require(Agent.authenticators[index - 1]);
-    previousAuthenticatorPromise
-      .then((response) => {
-        this.logger.debug(
-          `Authenticator ${previousAuthenticator.authenticatorName} succeed.`
-        );
-        callBack(response);
-      })
-      .catch((err) => {
-        let fatalError = this.fatalAuthenticateError(
-          err,
-          previousAuthenticator
-        );
-        if (fatalError) {
-          callBackError(fatalError);
-        } else {
-          this.logger.warn(
-            `Authenticator ${previousAuthenticator.authenticatorName} failed.`,
-            err
-          );
-          if (index < Agent.authenticators.length) {
-            authenticator = require(Agent.authenticators[index]);
-            this.logger.debug(
-              `Try to authenticate over ${authenticator.authenticatorName} authenticator.`
-            );
-            this.tryAuthenticator(
-              ++index,
-              endpointUrl,
-              authenticator(this.settings, this, endpointUrl),
-              callBack,
-              callBackError
-            );
-          } else {
-            callBackError(
-              new Error(`Not valid authenticator found - ${err.message}.`)
-            );
-          }
-        }
-      });
-  }
-
-  /**
-   * Try authenticate user by particular authenticator. If authenticator
-   * fails try to use next authenticator from Agent.authenticators list.
-   * If all authenticators fails call callBackError parameter if any
-   * authenticator succeed call callBack parameter
-   *
-   * The method is used internally in the public authenticated method
-   *
-   * @private
-   *
-   * @param {Error} resError error based on the response
-   * @param {Object} previousAuthenticator authenticator object
-   *
-   * @returns {Error} returns object with fatal error which steps authentication
-   *
-   * @memberof Agent
-   */
-  fatalAuthenticateError(resError, previousAuthenticator) {
-    let fatalError;
-    if (!resError.unsupported) {
-      if (resError.response === undefined) {
-        fatalError = new Error(
-          `Authenticator ${previousAuthenticator.authenticatorName}: fatal error: ${resError}`
-        );
-      } else if (resError.response.forbidden) {
-        fatalError = new Error(
-          `Authenticator ${previousAuthenticator.authenticatorName}: forbidden: ${resError.response.res.text}`
-        );
-      } else if (resError.response.serverError) {
-        fatalError = new Error(
-          `Authenticator ${previousAuthenticator.authenticatorName}: server error: ${resError.response.res.text}`
-        );
-      }
-    }
-    return fatalError;
   }
 
   /**

--- a/lib/agent/authentication.js
+++ b/lib/agent/authentication.js
@@ -9,6 +9,63 @@ exports.AUTHENTICATORS = [
 ];
 
 /**
+ * Authenticate user by different ways defined
+ * by settings
+ *
+ * @param {Agent} agent instance of agent/Agent class which
+ *        is authorized
+ * @param {String} endpointUrl url of metadata, which is used as
+ *        root of service
+ *
+ * @return {Promise} promise which is resolve when first authenticator succeed
+ *        or reject if all authenticators fails
+ *
+ * @public
+ */
+exports.authenticate = function (agent, endpointUrl) {
+  let promise;
+
+  if (_.has(agent, "settings.auth.cookies")) {
+    promise = exports.authenticateByCookie(agent, endpointUrl);
+  } else {
+    promise = exports.authenticateAuto(agent, endpointUrl);
+  }
+
+  return promise;
+};
+
+exports.authenticateByCookie = function (agent, endpointUrl) {
+  let promise;
+
+  const cookies = agent.settings.auth.cookies;
+
+  if (_.isArray(cookies)) {
+    promise = Promise.all(
+      cookies.map(
+        (cookie) =>
+          new Promise((resolve, reject) => {
+            agent.cookieJar.setCookie(
+              cookie,
+              endpointUrl,
+              (err, savedCookie) => {
+                if (err) {
+                  reject(err);
+                } else {
+                  resolve(savedCookie);
+                }
+              }
+            );
+          })
+      )
+    );
+  } else {
+    promise = Promise.reject(new Error("Invalid cookie definition."));
+  }
+
+  return promise;
+};
+
+/**
  * Authenticate user by authenticators. Authenticators are modules
  * in lib/agent/authentication/. List of modules is in Agent.authenticators
  * array. Authenticate method calls authenticators in order of list.
@@ -24,7 +81,7 @@ exports.AUTHENTICATORS = [
  *
  * @public
  */
-exports.authenticate = function (agent, endpointUrl) {
+exports.authenticateAuto = function (agent, endpointUrl) {
   return new Promise((resolve, reject) => {
     let authenticator;
     if (

--- a/lib/agent/authentication.js
+++ b/lib/agent/authentication.js
@@ -1,0 +1,160 @@
+"use strict";
+
+const _ = require("lodash");
+
+exports.AUTHENTICATORS = [
+  require("./authentication/samlSap"),
+  require("./authentication/basic"),
+  require("./authentication/none"),
+];
+
+/**
+ * Authenticate user by authenticators. Authenticators are modules
+ * in lib/agent/authentication/. List of modules is in Agent.authenticators
+ * array. Authenticate method calls authenticators in order of list.
+ * User is authenticated when first authenticator succeed.
+ *
+ * @param {Agent} agent instance of agent/Agent class which
+ *        is authorized
+ * @param {String} endpointUrl url of metadata, which is used as
+ *        root of service
+ *
+ * @return {Promise} promise which is resolve when first authenticator succeed
+ *        or reject if all authenticators fails
+ *
+ * @public
+ */
+exports.authenticate = function (agent, endpointUrl) {
+  return new Promise((resolve, reject) => {
+    let authenticator;
+    if (
+      _.isArray(exports.AUTHENTICATORS) &&
+      exports.AUTHENTICATORS.length > 0
+    ) {
+      authenticator = exports.AUTHENTICATORS[0];
+      agent.logger.debug(
+        `Try to authenticate over ${authenticator.authenticatorName} authenticator.`
+      );
+      exports.tryAuthenticator(1, endpointUrl, {
+        authentcatePromise: authenticator(agent.settings, agent, endpointUrl),
+        success: resolve,
+        error: reject,
+        agent: agent,
+      });
+    } else {
+      reject(new Error("Authenticators are not defined."));
+    }
+  });
+};
+
+/**
+ * Try authenticate user by particular authenticator. If authenticator
+ * fails try to use next authenticator from Agent.authenticators list.
+ * If all authenticators fails call callBackError parameter if any
+ * authenticator succeed call callBack parameter
+ *
+ * The method is used internally in the public authenticated method
+ *
+ * @private
+ *
+ * @param {Number} index to the Agent.authenticators which is used
+ * @param {String} endpointUrl url of metadata, which is used as
+ *        root of service
+ * @param {Object} init map with additonal parameters
+ *        authentcatePromise - previous authenticator promise
+ *                 determine previous authenticator result
+ *        success - function which is called when authenticator
+ *                 succeed
+ *        error - function which is called when all authenticators
+ *                 fails
+ * @private
+ */
+exports.tryAuthenticator = function (index, endpointUrl, init) {
+  let previousAuthenticator;
+  let authenticator;
+
+  const previousAuthenticatorPromise = init.authentcatePromise;
+  const callBack = init.success;
+  const callBackError = init.error;
+  const agent = init.agent;
+
+  previousAuthenticator = exports.AUTHENTICATORS[index - 1];
+  previousAuthenticatorPromise
+    .then((response) => {
+      agent.logger.debug(
+        `Authenticator ${previousAuthenticator.authenticatorName} succeed.`
+      );
+      callBack(response);
+    })
+    .catch((err) => {
+      let fatalError = exports.fatalAuthenticateError(
+        err,
+        previousAuthenticator
+      );
+      if (fatalError) {
+        callBackError(fatalError);
+      } else {
+        agent.logger.warn(
+          `Authenticator ${previousAuthenticator.authenticatorName} failed.`,
+          err
+        );
+        if (index < exports.AUTHENTICATORS.length) {
+          authenticator = exports.AUTHENTICATORS[index];
+          agent.logger.debug(
+            `Try to authenticate over ${authenticator.authenticatorName} authenticator.`
+          );
+          exports.tryAuthenticator(++index, endpointUrl, {
+            authentcatePromise: authenticator(
+              agent.settings,
+              agent,
+              endpointUrl
+            ),
+            success: callBack,
+            error: callBackError,
+            agent: agent,
+          });
+        } else {
+          callBackError(
+            new Error(`Not valid authenticator found - ${err.message}.`)
+          );
+        }
+      }
+    });
+};
+
+/**
+ * Try authenticate user by particular authenticator. If authenticator
+ * fails try to use next authenticator from Agent.authenticators list.
+ * If all authenticators fails call callBackError parameter if any
+ * authenticator succeed call callBack parameter
+ *
+ * The method is used internally in the public authenticated method
+ *
+ * @private
+ *
+ * @param {Error} resError error based on the response
+ * @param {Object} previousAuthenticator authenticator object
+ *
+ * @returns {Error} returns object with fatal error which steps authentication
+ *
+ * @private
+ */
+exports.fatalAuthenticateError = function (resError, previousAuthenticator) {
+  let fatalError;
+  if (!resError.unsupported) {
+    if (resError.response === undefined) {
+      fatalError = new Error(
+        `Authenticator ${previousAuthenticator.authenticatorName}: fatal error: ${resError}`
+      );
+    } else if (resError.response.forbidden) {
+      fatalError = new Error(
+        `Authenticator ${previousAuthenticator.authenticatorName}: forbidden: ${resError.response.res.text}`
+      );
+    } else if (resError.response.serverError) {
+      fatalError = new Error(
+        `Authenticator ${previousAuthenticator.authenticatorName}: server error: ${resError.response.res.text}`
+      );
+    }
+  }
+  return fatalError;
+};

--- a/lib/agent/settings.js
+++ b/lib/agent/settings.js
@@ -174,7 +174,7 @@ function parseCa(connectionSettings, parameters) {
  *
  * @return {Object} structure used by the client to connect the server
  */
-module.exports = function (connectionSettings = process.env.ODATA_URL) {
+function parseSettings(connectionSettings = process.env.ODATA_URL) {
   var parameters = {
     url: null,
     strict:
@@ -196,7 +196,67 @@ module.exports = function (connectionSettings = process.env.ODATA_URL) {
   } else {
     throw new Error("Invalid OData service connection settings");
   }
+
   parameters = parseCa(connectionSettings, parameters);
+  parameters = parseSettings._.parseConnectionCookie(
+    connectionSettings,
+    parameters
+  );
+
+  return parameters;
+}
+
+parseSettings._ = {};
+
+/**
+ * Try to get cookies from environment variable
+ *
+ * @param {Object} connectionSettings - object which could contains corrently defined url
+ * @param {Object} parameters - reference to parameter structure which is updated by method
+ *
+ * @return {Object} returns structure defining OData endpoint
+ */
+parseSettings._.parseConnectionCookie = function parseConnectionCookie(
+  connectionSettings,
+  parameters
+) {
+  let cookies;
+
+  if (!parseSettings._.checkCookieSettings(connectionSettings)) {
+    throw new Error("Invalid cookie definition");
+  }
+
+  if (_.has(connectionSettings, "auth.cookies")) {
+    _.set(parameters, "auth.cookies", connectionSettings.auth.cookies);
+  } else if (process.env.ODATA_COOKIE) {
+    try {
+      cookies = JSON.parse(process.env.ODATA_COOKIE);
+    } catch (err) {
+      cookies = [process.env.ODATA_COOKIE];
+    }
+    _.set(parameters, "auth.cookies", cookies);
+  }
 
   return parameters;
 };
+
+parseSettings._.checkCookieSettings = function (connectionSettings) {
+  let check = true;
+
+  if (_.has(connectionSettings, "auth.cookies")) {
+    check =
+      _.isArray(connectionSettings.auth.cookies) &&
+      connectionSettings.auth.cookies.every((cookie) => _.isString(cookie));
+  } else if (_.has(process.env, "ODATA_COOKIE")) {
+    try {
+      let cookieToCheck = JSON.parse(process.env.ODATA_COOKIE);
+      check = _.isArray(cookieToCheck);
+    } catch (err) {
+      check = _.isString(process.env.ODATA_COOKIE);
+    }
+  }
+
+  return check;
+};
+
+module.exports = parseSettings;

--- a/test/unit/agent/authentication.js
+++ b/test/unit/agent/authentication.js
@@ -1,0 +1,259 @@
+"use strict";
+
+const assert = require("assert").strict;
+const sinon = require("sinon");
+const _ = require("lodash");
+const authentication = require("../../../lib/agent/authentication");
+
+let sandbox = sinon.createSandbox();
+
+describe("lib/engine/agent/authentication", function () {
+  afterEach(() => sandbox.restore());
+
+  describe(".authenticate", function () {
+    let backupAuthenticators;
+    let agent;
+    beforeEach(() => {
+      backupAuthenticators = authentication.AUTHENTICATORS;
+      authentication.AUTHENTICATORS = _.clone(backupAuthenticators);
+      agent = {
+        logger: {
+          debug: sinon.stub(),
+        },
+        settings: "SETTINGS",
+      };
+    });
+    afterEach(() => {
+      authentication.AUTHENTICATORS = backupAuthenticators;
+    });
+    it("if authenticators does not exists raise error.", function () {
+      authentication.AUTHENTICATORS = null;
+      return authentication
+        .authenticate(agent, "URL")
+        .then(() => assert.ok(false))
+        .catch((err) => assert.ok(err.message.match(/not defined/)));
+    });
+    it("if authenticators are empty raise error.", function () {
+      authentication.AUTHENTICATORS = [];
+      return authentication
+        .authenticate(agent, "URL")
+        .then(() => assert.ok(false))
+        .catch((err) => assert.ok(err.message.match(/not defined/)));
+    });
+    it("Initialize authenticating by first authenticator with correct authentication", function () {
+      let promise;
+      sandbox.stub(authentication, "tryAuthenticator");
+      authentication.AUTHENTICATORS = [sinon.stub().returns("AUTHENTICATOR")];
+      promise = authentication.authenticate(agent, "URL").then(() => {
+        assert.ok(authentication.tryAuthenticator.calledOnce);
+        assert.ok(authentication.tryAuthenticator.calledWith(1, "URL"));
+        assert.deepEqual(authentication.AUTHENTICATORS[0].getCall(0).args, [
+          "SETTINGS",
+          agent,
+          "URL",
+        ]);
+      });
+
+      setTimeout(() => {
+        authentication.tryAuthenticator.getCall(0).args[2].success();
+      }, 0);
+      return promise;
+    });
+    it("Initialize authenticating by first authenticator but all authenticators failed", function () {
+      let promise;
+      sandbox.stub(authentication, "tryAuthenticator");
+      authentication.AUTHENTICATORS = [sinon.stub().returns("AUTHENTICATOR")];
+      promise = authentication
+        .authenticate(agent, "URL")
+        .then(() => assert.ok(false))
+        .catch(() => {
+          assert.ok(authentication.tryAuthenticator.calledOnce);
+          assert.ok(authentication.tryAuthenticator.calledWith(1, "URL"));
+          assert.deepEqual(authentication.AUTHENTICATORS[0].getCall(0).args, [
+            "SETTINGS",
+            agent,
+            "URL",
+          ]);
+        });
+
+      setTimeout(() => {
+        authentication.tryAuthenticator.getCall(0).args[2].success();
+      }, 0);
+      return promise;
+    });
+  });
+
+  describe(".tryAuthenticator", function () {
+    let agent;
+    beforeEach(() => {
+      agent = {
+        logger: {
+          debug: sinon.stub(),
+          warn: sinon.stub(),
+        },
+      };
+
+      authentication.AUTHENTICATORS[0] = sinon.stub();
+      authentication.AUTHENTICATORS[1] = sinon.stub();
+      authentication.AUTHENTICATORS[2] = sinon.stub();
+    });
+
+    it("Succeed on first authenticator", function (done) {
+      authentication.AUTHENTICATORS[0].authenticatorName = "AUTHENTICATOR";
+      authentication.tryAuthenticator(1, "URL", {
+        authentcatePromise: Promise.resolve("RESPONSE"),
+        agent: agent,
+        success: function (response) {
+          assert.equal(response, "RESPONSE");
+          assert.ok(
+            agent.logger.debug.getCall(0).args[0].match(/AUTHENTICATOR/)
+          );
+          done();
+        },
+      });
+    });
+    it("Succeed on next authenticator", function (done) {
+      authentication.AUTHENTICATORS[0].authenticatorName =
+        "FIRST_AUTHENTICATOR";
+      authentication.AUTHENTICATORS[1].returns(Promise.resolve("RESPONSE"));
+      authentication.AUTHENTICATORS[1].authenticatorName =
+        "SECOND_AUTHENTICATOR";
+
+      authentication.tryAuthenticator(1, "URL", {
+        authentcatePromise: Promise.reject({
+          message: "ERROR",
+          unsupported: true,
+        }),
+        agent: agent,
+        success: function () {
+          assert.ok(
+            agent.logger.debug.getCall(0).args[0].match(/SECOND_AUTHENTICATOR/)
+          );
+          assert.ok(
+            agent.logger.warn.getCall(0).args[0].match(/FIRST_AUTHENTICATOR/)
+          );
+          assert.ok(
+            agent.logger.debug.getCall(1).args[0].match(/SECOND_AUTHENTICATOR/)
+          );
+          done();
+        },
+      });
+    });
+    it("Fails on all authenticators", function (done) {
+      authentication.AUTHENTICATORS[1].returns(
+        Promise.reject({
+          message: "ERROR MESSAGE",
+          unsupported: true,
+        })
+      );
+      authentication.AUTHENTICATORS[2].returns(
+        Promise.reject({
+          message: "ERROR MESSAGE",
+          unsupported: true,
+        })
+      );
+
+      authentication.tryAuthenticator(1, "URL", {
+        authentcatePromise: Promise.reject({
+          message: "ERROR",
+          unsupported: true,
+        }),
+        agent: agent,
+        error: function (error) {
+          assert.equal(
+            error.message,
+            "Not valid authenticator found - ERROR MESSAGE."
+          );
+          done();
+        },
+      });
+    });
+    it("Stops if rejection is fatal", function (done) {
+      sandbox
+        .stub(authentication, "fatalAuthenticateError")
+        .returns("FATAL_ERROR");
+
+      authentication.tryAuthenticator(1, "URL", {
+        authentcatePromise: Promise.reject("Internet is down!"),
+        agent: agent,
+        error: function (error) {
+          assert.equal(error, "FATAL_ERROR");
+          done();
+        },
+      });
+    });
+    it("Error handler is permissive", function (done) {
+      authentication.AUTHENTICATORS[1].returns(Promise.resolve("RESPONSE"));
+
+      authentication.tryAuthenticator(1, "URL", {
+        authentcatePromise: Promise.reject({
+          response: {
+            forbidden: false,
+          },
+        }),
+        agent: agent,
+        success: function (response) {
+          assert.equal(response, "RESPONSE");
+          done();
+        },
+      });
+    });
+  });
+
+  describe(".fatalAuthenticateError", function () {
+    it("No error for non-fatal issue", function () {
+      assert.strictEqual(
+        authentication.fatalAuthenticateError({
+          unsupported: true,
+        }),
+        undefined
+      );
+    });
+    it("No network connection.", function () {
+      let err = authentication.fatalAuthenticateError(
+        {},
+        {
+          authenticatorName: "AUTHENTICATOR_NAME",
+        }
+      );
+      assert.ok(err instanceof Error);
+      assert.ok(err.message.indexOf("AUTHENTICATOR_NAME") > -1);
+    });
+    it("Forbidden respons", function () {
+      let err = authentication.fatalAuthenticateError(
+        {
+          response: {
+            forbidden: true,
+            res: {
+              text: "FORBIDDEN",
+            },
+          },
+        },
+        {
+          authenticatorName: "AUTHENTICATOR_NAME",
+        }
+      );
+      assert.ok(err instanceof Error);
+      assert.ok(err.message.indexOf("AUTHENTICATOR_NAME") > -1);
+      assert.ok(err.message.indexOf("FORBIDDEN") > -1);
+    });
+    it("Internal server error response", function () {
+      let err = authentication.fatalAuthenticateError(
+        {
+          response: {
+            serverError: true,
+            res: {
+              text: "SERVER_ERROR",
+            },
+          },
+        },
+        {
+          authenticatorName: "AUTHENTICATOR_NAME",
+        }
+      );
+      assert.ok(err instanceof Error);
+      assert.ok(err.message.indexOf("AUTHENTICATOR_NAME") > -1);
+      assert.ok(err.message.indexOf("SERVER_ERROR") > -1);
+    });
+  });
+});


### PR DESCRIPTION
Hi, 

I have receive request to authenticate odata-library agent externally and then pass authentication cookies to the odata-library agent.

I have moved authentication code to separate module in first commit (just to decrease size of Agent.js) and then I have added cookie based authentication.

How to use cookies for authentication is in documentation.



