### PR TITLE
Ignore invalid mode for FunctionImport in non-strict mode

### DIFF
--- a/lib/model/nw/dataSource/FunctionImportParameter.js
+++ b/lib/model/nw/dataSource/FunctionImportParameter.js
@@ -33,21 +33,27 @@ class FunctionImportParameter {
    * @memberof FunctionImportParameter
    */
   constructor(rawMetadata, schema) {
+    let mode = rawMetadata.$.Mode;
     defineProperty(this, "raw", rawMetadata);
     defineProperty(this, "name", rawMetadata.$.Name);
 
     defineProperty(this, "type", schema.getType(rawMetadata.$.Type));
-    defineProperty(this, "mode", rawMetadata.$.Mode);
     defineOptionalNumber(this, "MaxLength");
     defineProperty(this, "nullable", rawMetadata.$.Nullable !== "false");
     defineOptionalNumber(this, "Precision");
     defineOptionalNumber(this, "Scale");
 
-    if (!["In", "Out", "InOut"].includes(this.mode)) {
-      throw new Error(
-        `Unknown mode '${this.mode} for function import parameter '${this.name}`
-      );
+    if (!["In", "Out", "InOut"].includes(mode)) {
+      if (schema.settings.strict !== false) {
+        throw new Error(
+          `Unknown mode '${this.mode} for function import parameter '${this.name}`
+        );
+      } else {
+        mode = "In";
+      }
     }
+
+    defineProperty(this, "mode", mode);
 
     let extensions = [];
     defineProperty(this, "extensions", extensions);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "http-parser-js": "^0.5.0",
-    "jsdom": "^13.2.0",
+    "jsdom": "^16.5.0",
     "lodash": "^4.17.10",
     "node-fetch": "^2.6.7",
     "tough-cookie": "^4.0.0",

--- a/test/unit/model/nw/dataSource/FunctionImportParameter.js
+++ b/test/unit/model/nw/dataSource/FunctionImportParameter.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const assert = require("assert");
+const assert = require("assert").strict;
 const _ = require("lodash");
 const FunctionImportParameter = require("../../../../../lib/model/nw/dataSource/FunctionImportParameter");
 const sampleMD = {
@@ -72,6 +72,28 @@ describe("FunctionImportParameter", function () {
             sampleSchema
           )
       );
+    });
+
+    it("Do not throws error on invalid metadata for non-strict mode", function () {
+      const functionImportParameter = new FunctionImportParameter(
+        {
+          $: {
+            Mode: "None",
+            Name: "name",
+            Type: "Edm.String",
+          },
+        },
+        Object.assign(
+          {
+            settings: {
+              strict: false,
+            },
+          },
+          sampleSchema
+        )
+      );
+
+      assert.equal(functionImportParameter.mode, "In");
     });
   });
 


### PR DESCRIPTION
Olingo generates FunctionImport tag in metadata without Mode parameter. The patch enables correct metadata parsing in non-strict mode.