### PR TITLE
[FEATURE] Send navigation properties for v4

### DIFF
--- a/lib/engine/QueryableResource.js
+++ b/lib/engine/QueryableResource.js
@@ -484,8 +484,7 @@ class QueryableResource extends Resource {
       .map((navigationProperty) =>
         this.processNavigationPropertyItems(
           navigationProperty,
-          entityTypeProperties,
-          entityTypeModel
+          entityTypeProperties
         )
       )
       .reduce(
@@ -496,16 +495,20 @@ class QueryableResource extends Resource {
       .value();
   }
 
-  processNavigationPropertyItems(
-    navigationProperty,
-    entityTypeProperties,
-    entityTypeModelStart
-  ) {
-    let assoociationEnd = entityTypeModelStart.navigationPropertyAssociationTo(
-      navigationProperty.name
-    );
-    let entityTypeModelEnd = _.get(assoociationEnd, "type");
-    let navigationPropertyItems = entityTypeProperties[navigationProperty.name];
+  /**
+   * Go thru navigation propert items for active operations
+   * (post, merge, put)
+   *
+   * @param {NavigationProperty} navigationProperty object which represents
+   *        navigation property definition for v2 or v4
+   * @param {Object} entityTypeProperties data for navigation properties
+   *
+   * @returns {Object} checked navigation properties items
+   */
+  processNavigationPropertyItems(navigationProperty, entityTypeProperties) {
+    const entityTypeModelEnd = _.get(navigationProperty, "type.elementType");
+    const navigationPropertyItems =
+      entityTypeProperties[navigationProperty.name];
     let navigationPropertyItemsProcessed;
 
     if (!_.isObject(entityTypeModelEnd)) {
@@ -514,10 +517,7 @@ class QueryableResource extends Resource {
       );
     }
 
-    if (
-      assoociationEnd.multiplicity === "*" &&
-      _.isArray(navigationPropertyItems)
-    ) {
+    if (navigationProperty.isCollection && _.isArray(navigationPropertyItems)) {
       navigationPropertyItemsProcessed = _.map(
         navigationPropertyItems,
         (navigationPropertyItemsToProcess) => {

--- a/lib/model/nw/schema/EntityType.js
+++ b/lib/model/nw/schema/EntityType.js
@@ -37,7 +37,7 @@ class EntityType extends ComplexType {
     });
 
     let navigationProperties = _.get(this.raw, "NavigationProperty", []).map(
-      (p) => new NavigationProperty(p)
+      (p) => new NavigationProperty(p, model)
     );
     Object.defineProperty(this, "navigationProperties", {
       get: () => navigationProperties,
@@ -145,52 +145,6 @@ class EntityType extends ComplexType {
     }
 
     return this.raw.Key[0].PropertyRef.map((pr) => this.getProperty(pr.$.Name));
-  }
-
-  /**
-   * Find association
-   *
-   * @param {String} navigationPropertyName name of the navigation property
-   *
-   * @returns {AssociationEnd}  association endpoint to the navigation property  entity type
-   *
-   * @memberof EntityType
-   *
-   * @private
-   */
-  navigationPropertyAssociationTo(navigationPropertyName) {
-    let association;
-    let associationEnd;
-    let navigationPropertyDefinition = _.find(
-      this.navigationProperties,
-      (navigationProperty) => navigationProperty.name === navigationPropertyName
-    );
-
-    if (!navigationPropertyDefinition) {
-      throw new Error(
-        `Navigation property ${navigationPropertyName} does not exists in the ${this.name} EntityType.`
-      );
-    }
-
-    association = this.model.resolveModelPath(
-      navigationPropertyDefinition.relationship
-    );
-
-    if (!association) {
-      throw new Error(
-        `Association for navigation property ${navigationPropertyName} from EntityType ${this.name} does not exists.`
-      );
-    }
-
-    associationEnd = association.findEnd(navigationPropertyDefinition.toRole);
-
-    if (!associationEnd) {
-      throw new Error(
-        `Association endpoint for navigation property ${navigationPropertyName} from EntityType ${this.name} does not exists.`
-      );
-    }
-
-    return associationEnd;
   }
 }
 

--- a/lib/model/nw/schema/NavigationProperty.js
+++ b/lib/model/nw/schema/NavigationProperty.js
@@ -19,8 +19,9 @@ class NavigationProperty extends AnnotationTarget {
    * @param {Object} rawMetadata raw metadata object for navigation property
    * @memberof NavigationProperty
    */
-  constructor(rawMetadata) {
-    super(rawMetadata);
+  constructor(...args) {
+    const rawMetadata = args[0];
+    super(...args);
 
     Object.defineProperty(this, "relationship", {
       get: () => rawMetadata.$.Relationship,
@@ -32,6 +33,46 @@ class NavigationProperty extends AnnotationTarget {
 
     Object.defineProperty(this, "toRole", {
       get: () => rawMetadata.$.ToRole,
+    });
+
+    Object.defineProperty(this, "association", {
+      get: () => {
+        const association = this.model.resolveModelPath(this.relationship);
+        if (!association) {
+          throw new Error(
+            `Association for navigation property ${this.name} does not exists.`
+          );
+        }
+        return association;
+      },
+    });
+
+    Object.defineProperty(this, "associationEnd", {
+      get: () => {
+        const associationEnd = this.association.findEnd(this.toRole);
+
+        if (!associationEnd) {
+          throw new Error(
+            `Association endpoint for navigation property ${this.name} does not exists.`
+          );
+        }
+
+        return associationEnd;
+      },
+    });
+
+    Object.defineProperty(this, "type", {
+      get: () => {
+        return {
+          elementType: this.associationEnd.type,
+        };
+      },
+    });
+
+    Object.defineProperty(this, "isCollection", {
+      get: () => {
+        return this.associationEnd.multiplicity === "*";
+      },
     });
   }
 

--- a/lib/model/oasis/schema/EdmSimpleType.js
+++ b/lib/model/oasis/schema/EdmSimpleType.js
@@ -136,7 +136,7 @@ instances = [
   ),
   new EdmSimpleType("Date"),
   new EdmSimpleType("DateTimeOffset", formatDateTime, formatDateTime),
-  new EdmSimpleType("Decimal"),
+  new EdmSimpleType("Decimal", _.toNumber, _.toNumber),
   new EdmSimpleType("Double"),
   new EdmSimpleType("Duration"),
   new EdmSimpleType("Guid", getGuidValue, getGuidValue),

--- a/test/unit/engine/QueryableResource.js
+++ b/test/unit/engine/QueryableResource.js
@@ -1059,48 +1059,33 @@ describe("QueryableResource", function () {
   });
 
   describe(".processNavigationPropertyItems()", function () {
-    it("Missing entity type definition for the navigation property", function () {
-      let navigationProperty = {
+    let navigationProperty;
+    let entityTypeProperties;
+    beforeEach(() => {
+      navigationProperty = {
         name: "navPropKey1",
+        isCollection: false,
       };
-      let entityTypeProperties = {
+      entityTypeProperties = {
         navPropKey1: "NAV_PROP_1",
       };
-      let entityTypeModel = {
-        navigationPropertyAssociationTo: sinon.stub(),
-      };
-      innerMetadata.model = "MODEL";
+    });
+    it("Missing entity type definition for the navigation property", function () {
       assert.throws(() => {
         entitySet.processNavigationPropertyItems(
           navigationProperty,
-          entityTypeProperties,
-          entityTypeModel
+          entityTypeProperties
         );
       }, /End EntityType/);
-      assert.ok(
-        entityTypeModel.navigationPropertyAssociationTo.calledWith(
-          "navPropKey1"
-        )
-      );
     });
+
     it("Process navigation property with multiplicity 1:1", function () {
-      let navigationProperty = {
-        name: "navPropKey1",
-      };
-      let entityTypeProperties = {
-        navPropKey1: "NAV_PROP_1",
-      };
-      let assoociationEnd = {
-        multiplicity: "1",
-        type: {
+      navigationProperty.type = {
+        elementType: {
           properties: "NAVIGATION_PROPERTIES",
         },
       };
-      let entityTypeModel = {
-        navigationPropertyAssociationTo: sinon.stub().returns(assoociationEnd),
-      };
 
-      innerMetadata.model = "MODEL";
       sinon.stub(entitySet, "processProperties").returns({
         processedProperty: "VALUE",
       });
@@ -1111,8 +1096,7 @@ describe("QueryableResource", function () {
       assert.deepEqual(
         entitySet.processNavigationPropertyItems(
           navigationProperty,
-          entityTypeProperties,
-          entityTypeModel
+          entityTypeProperties
         ),
         {
           navPropKey1: {
@@ -1120,11 +1104,6 @@ describe("QueryableResource", function () {
             processedNavigationProperty: "VALUE",
           },
         }
-      );
-      assert.ok(
-        entityTypeModel.navigationPropertyAssociationTo.calledWith(
-          "navPropKey1"
-        )
       );
       assert.ok(
         entitySet.processProperties.calledWith(
@@ -1135,28 +1114,19 @@ describe("QueryableResource", function () {
       assert.ok(
         entitySet.processNavigationProperties.calledWith(
           "NAV_PROP_1",
-          assoociationEnd.type
+          navigationProperty.type.elementType
         )
       );
     });
     it("Process navigation property with multiplicity 1:N", function () {
-      let navigationProperty = {
-        name: "navPropKey1",
-      };
-      let entityTypeProperties = {
-        navPropKey1: ["NAV_PROP_1_0", "NAV_PROP_1_1"],
-      };
-      let assoociationEnd = {
-        multiplicity: "*",
-        type: {
+      navigationProperty.isCollection = true;
+      navigationProperty.type = {
+        elementType: {
           properties: "PROPERTIES",
         },
       };
-      let entityTypeModel = {
-        navigationPropertyAssociationTo: sinon.stub().returns(assoociationEnd),
-      };
+      entityTypeProperties.navPropKey1 = ["NAV_PROP_1_0", "NAV_PROP_1_1"];
 
-      innerMetadata.model = "MODEL";
       sinon.stub(entitySet, "processProperties").returns({
         processedProperty: "VALUE",
       });
@@ -1167,8 +1137,7 @@ describe("QueryableResource", function () {
       assert.deepEqual(
         entitySet.processNavigationPropertyItems(
           navigationProperty,
-          entityTypeProperties,
-          entityTypeModel
+          entityTypeProperties
         ),
         {
           navPropKey1: [
@@ -1184,11 +1153,6 @@ describe("QueryableResource", function () {
         }
       );
       assert.ok(
-        entityTypeModel.navigationPropertyAssociationTo.calledWithExactly(
-          "navPropKey1"
-        )
-      );
-      assert.ok(
         entitySet.processProperties
           .getCall(0)
           .calledWith("NAV_PROP_1_0", "PROPERTIES")
@@ -1202,12 +1166,12 @@ describe("QueryableResource", function () {
       assert.ok(
         entitySet.processNavigationProperties
           .getCall(0)
-          .calledWith("NAV_PROP_1_0", assoociationEnd.type)
+          .calledWith("NAV_PROP_1_0", navigationProperty.type.elementType)
       );
       assert.ok(
         entitySet.processNavigationProperties
           .getCall(1)
-          .calledWith("NAV_PROP_1_1", assoociationEnd.type)
+          .calledWith("NAV_PROP_1_1", navigationProperty.type.elementType)
       );
       assert.ok(entitySet.processNavigationProperties.calledTwice);
     });

--- a/test/unit/model/nw/schema/EntityType.js
+++ b/test/unit/model/nw/schema/EntityType.js
@@ -2,7 +2,6 @@
 
 const _ = require("lodash");
 const assert = require("assert").strict;
-const sinon = require("sinon");
 const EntityType = require("../../../../../lib/model/nw/schema/EntityType");
 
 const sampleEntityTypeMD = {
@@ -100,7 +99,11 @@ describe("EntityType (nw)", function () {
       assert.equal(type.raw, sampleEntityTypeMD);
       assert.equal(type.name, "EntityType1");
       assert.ok(_.isArray(type.properties));
-      assert.ok(_.isArray(type.navigationProperties));
+      assert.equal(
+        sampleEntityTypeMD.NavigationProperty.length,
+        type.navigationProperties.length
+      );
+      assert.equal(type.navigationProperties[0].model, model);
       assert.ok(_.isArray(type.key));
       assert.equal(type.model, model);
     });
@@ -189,38 +192,6 @@ describe("EntityType (nw)", function () {
       assert.ok(_.has(api, "NavigationProperties"));
       assert.equal(api.NavigationProperties.NavProp1.Name, "NavProp1");
       assert.ok(_.isArray(api.Key));
-    });
-  });
-
-  describe(".navigationPropertyAssociationTo()", function () {
-    it("Missing navigation property raises error.", function () {
-      assert.throws(() => {
-        type.navigationPropertyAssociationTo("NavPropMissing");
-      }, /Navigation property/);
-    });
-    it("Missing association raises error.", function () {
-      model.resolveModelPath = sinon.stub();
-      assert.throws(() => {
-        type.navigationPropertyAssociationTo("NavProp1");
-      }, /Association for/);
-    });
-    it("Missing association end raises error.", function () {
-      model.resolveModelPath = sinon.stub().returns({
-        findEnd: sinon.stub(),
-      });
-      assert.throws(() => {
-        type.navigationPropertyAssociationTo("NavProp1");
-      }, /Association endpoint/);
-    });
-
-    it("Association end found.", function () {
-      model.resolveModelPath = sinon.stub().returns({
-        findEnd: sinon.stub().returns("ASSOCIATION_END"),
-      });
-      assert.strictEqual(
-        type.navigationPropertyAssociationTo("NavProp1"),
-        "ASSOCIATION_END"
-      );
     });
   });
 });

--- a/test/unit/model/oasis/schema/EdmSimpleType.js
+++ b/test/unit/model/oasis/schema/EdmSimpleType.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const assert = require("assert");
+const assert = require("assert").strict;
 const EdmSimpleType = require("../../../../../lib/model/oasis/schema/EdmSimpleType");
 
 function getType(name) {
@@ -120,5 +120,14 @@ describe("EdmSimpleType (oasis)", function () {
     assert.strictEqual(type.formatBody(1), "1");
     assert.strictEqual(type.formatBody("TEST"), "TEST");
     assert.strictEqual(type.formatBody("#"), "#");
+  });
+
+  it("handles Decimal", function () {
+    let type = getType("Decimal");
+    assert.equal(type.format(true), 1);
+    assert.equal(type.format(10.25), 10.25);
+    assert.equal(type.format("10.25"), 10.25);
+    assert.ok(isNaN(type.format({})));
+    assert.ok(isNaN(type.format("foo")));
   });
 });


### PR DESCRIPTION
Create entities by navigation properties ("deep
insert") was not implemented for v4. The patch
unified API for v4 & v2 metadata NavigationProperty
classes.

Topic: #68
