### PR TITLE
Force to use specific authenticator

### DIFF
--- a/doc/INITIALIZE.md
+++ b/doc/INITIALIZE.md
@@ -41,15 +41,12 @@ You can pass url and othere settings by object passed to the Service constructor
 You can also combine definitions. The parameter definition has precedence before
 definitons in the environment variables.
 
-```shell
-export NODE_EXTRA_CA_CERTS=/etc/ssl/certificates/root.crt
-```
-
 ```javascript
 const service = new Service({
   url: "https://localhost/service/",
   annotationsUrl: "https://localhost/serviceMetadata/annotations",
   auth: {
+    type: "basic"
     username: "foo",
     password: "bar",
   },
@@ -66,6 +63,18 @@ service.init.then(() => {
   //Code
 });
 ```
+
+## Authentication types
+
+The odata-library currently support four authentication types.
+
+- none - authentication is not needed
+- basic - [use basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication)
+- samlSap - specific authentication for sap based services
+- cookie - run authentication code externally and just pass authentication cookies to odata-library
+
+If authentication type is not specified odata-library tries to use first three authentication
+types automatically.
 
 ## Authenticate to service outside of Service
 

--- a/lib/agent/authentication.js
+++ b/lib/agent/authentication.js
@@ -2,10 +2,16 @@
 
 const _ = require("lodash");
 
+exports.AUTHENTICATORS = {
+  basic: require("./authentication/basic"),
+  none: require("./authentication/none"),
+  samlSap: require("./authentication/samlSap"),
+};
+
 exports.AUTHENTICATORS_AUTO_ORDER = [
-  require("./authentication/samlSap"),
-  require("./authentication/basic"),
-  require("./authentication/none"),
+  exports.AUTHENTICATORS.samlSap,
+  exports.AUTHENTICATORS.basic,
+  exports.AUTHENTICATORS.none,
 ];
 
 /**
@@ -25,7 +31,16 @@ exports.AUTHENTICATORS_AUTO_ORDER = [
 exports.authenticate = function (agent, endpointUrl) {
   let promise;
 
-  if (_.has(agent, "settings.auth.cookies")) {
+  if (_.has(agent, "settings.auth.type")) {
+    const authenticator = exports.AUTHENTICATORS[agent.settings.auth.type];
+    if (authenticator) {
+      promise = authenticator(agent.settings, agent, endpointUrl);
+    } else {
+      promise = Promise.reject(
+        new Error(`Missing authenticator type ${agent.settings.auth.type}`)
+      );
+    }
+  } else if (_.has(agent, "settings.auth.cookies")) {
     promise = exports.authenticateByCookie(agent, endpointUrl);
   } else {
     promise = exports.authenticateAuto(agent, endpointUrl);

--- a/lib/agent/authentication.js
+++ b/lib/agent/authentication.js
@@ -6,6 +6,7 @@ exports.AUTHENTICATORS = {
   basic: require("./authentication/basic"),
   none: require("./authentication/none"),
   samlSap: require("./authentication/samlSap"),
+  cookie: require("./authentication/cookie"),
 };
 
 exports.AUTHENTICATORS_AUTO_ORDER = [
@@ -40,41 +41,8 @@ exports.authenticate = function (agent, endpointUrl) {
         new Error(`Missing authenticator type ${agent.settings.auth.type}`)
       );
     }
-  } else if (_.has(agent, "settings.auth.cookies")) {
-    promise = exports.authenticateByCookie(agent, endpointUrl);
   } else {
     promise = exports.authenticateAuto(agent, endpointUrl);
-  }
-
-  return promise;
-};
-
-exports.authenticateByCookie = function (agent, endpointUrl) {
-  let promise;
-
-  const cookies = agent.settings.auth.cookies;
-
-  if (_.isArray(cookies)) {
-    promise = Promise.all(
-      cookies.map(
-        (cookie) =>
-          new Promise((resolve, reject) => {
-            agent.cookieJar.setCookie(
-              cookie,
-              endpointUrl,
-              (err, savedCookie) => {
-                if (err) {
-                  reject(err);
-                } else {
-                  resolve(savedCookie);
-                }
-              }
-            );
-          })
-      )
-    );
-  } else {
-    promise = Promise.reject(new Error("Invalid cookie definition."));
   }
 
   return promise;

--- a/lib/agent/authentication.js
+++ b/lib/agent/authentication.js
@@ -2,7 +2,7 @@
 
 const _ = require("lodash");
 
-exports.AUTHENTICATORS = [
+exports.AUTHENTICATORS_AUTO_ORDER = [
   require("./authentication/samlSap"),
   require("./authentication/basic"),
   require("./authentication/none"),
@@ -85,10 +85,10 @@ exports.authenticateAuto = function (agent, endpointUrl) {
   return new Promise((resolve, reject) => {
     let authenticator;
     if (
-      _.isArray(exports.AUTHENTICATORS) &&
-      exports.AUTHENTICATORS.length > 0
+      _.isArray(exports.AUTHENTICATORS_AUTO_ORDER) &&
+      exports.AUTHENTICATORS_AUTO_ORDER.length > 0
     ) {
-      authenticator = exports.AUTHENTICATORS[0];
+      authenticator = exports.AUTHENTICATORS_AUTO_ORDER[0];
       agent.logger.debug(
         `Try to authenticate over ${authenticator.authenticatorName} authenticator.`
       );
@@ -135,7 +135,7 @@ exports.tryAuthenticator = function (index, endpointUrl, init) {
   const callBackError = init.error;
   const agent = init.agent;
 
-  previousAuthenticator = exports.AUTHENTICATORS[index - 1];
+  previousAuthenticator = exports.AUTHENTICATORS_AUTO_ORDER[index - 1];
   previousAuthenticatorPromise
     .then((response) => {
       agent.logger.debug(
@@ -155,8 +155,8 @@ exports.tryAuthenticator = function (index, endpointUrl, init) {
           `Authenticator ${previousAuthenticator.authenticatorName} failed.`,
           err
         );
-        if (index < exports.AUTHENTICATORS.length) {
-          authenticator = exports.AUTHENTICATORS[index];
+        if (index < exports.AUTHENTICATORS_AUTO_ORDER.length) {
+          authenticator = exports.AUTHENTICATORS_AUTO_ORDER[index];
           agent.logger.debug(
             `Try to authenticate over ${authenticator.authenticatorName} authenticator.`
           );

--- a/lib/agent/authentication/cookie.js
+++ b/lib/agent/authentication/cookie.js
@@ -1,0 +1,85 @@
+"use strict";
+
+const _ = require("lodash");
+
+/**
+ * Try to load service endpoint by cookie authentication
+ *
+ * @param {Object} settings - normalized OData library settings
+ * @param {agent/Agent} agent - instance of superagent HTTP client
+ * @param {String} endpointUrl - url which is used for testing
+ *
+ * @return {Promise} the promise is resolved when endpoint is correctly loaded,
+ *                       the promise is rejected othewise
+ */
+function authenticate(settings, agent, endpointUrl) {
+  return authenticate
+    .setCookiesToAgent(settings, agent, endpointUrl)
+    .then(() => agent.fetch(endpointUrl))
+    .then(authenticate.processResponse);
+}
+
+/**
+ * Pass cookies for authentication to agent
+ *
+ * @param {Object} settings - normalized OData library settings
+ * @param {agent/Agent} agent - instance of superagent HTTP client
+ * @param {String} endpointUrl - url which is used for testing
+ *
+ * @return {Promise} the promise is resolved when cookies are set
+ */
+authenticate.setCookiesToAgent = function (settings, agent, endpointUrl) {
+  let promise;
+  const cookies = settings.auth.cookies;
+
+  if (_.isArray(cookies)) {
+    promise = Promise.all(
+      cookies.map(
+        (cookie) =>
+          new Promise((resolve, reject) => {
+            agent.cookieJar.setCookie(
+              cookie,
+              endpointUrl,
+              (err, savedCookie) => {
+                if (err) {
+                  reject(err);
+                } else {
+                  resolve(savedCookie);
+                }
+              }
+            );
+          })
+      )
+    );
+  } else {
+    promise = Promise.reject(new Error("Invalid cookie definition."));
+  }
+
+  return promise;
+};
+
+/**
+ * Check response from service endpoint to determine
+ * connection status. Throws for invalid statuses
+ *
+ * @param {HTTP.Response} response - object with HTTP response info
+ *
+ * @return {HTTP.Response} the valid response
+ */
+authenticate.processResponse = function (response) {
+  if (response.status > 299) {
+    throw new Error(
+      `Service rejects authentication with status code ${response.status}`
+    );
+  } else if (
+    !_.isString(response.headers.get("content-type")) ||
+    !response.headers.get("content-type").match(/application\/xml/)
+  ) {
+    throw new Error("Invalid metadata response for Cookie authentification");
+  }
+  return response;
+};
+
+authenticate.authenticatorName = "Cookie";
+
+module.exports = authenticate;

--- a/lib/agent/settings.js
+++ b/lib/agent/settings.js
@@ -228,6 +228,7 @@ parseSettings._.parseConnectionCookie = function parseConnectionCookie(
 
   if (_.has(connectionSettings, "auth.cookies")) {
     _.set(parameters, "auth.cookies", connectionSettings.auth.cookies);
+    _.set(parameters, "auth.type", "cookie");
   } else if (process.env.ODATA_COOKIE) {
     try {
       cookies = JSON.parse(process.env.ODATA_COOKIE);
@@ -235,6 +236,7 @@ parseSettings._.parseConnectionCookie = function parseConnectionCookie(
       cookies = [process.env.ODATA_COOKIE];
     }
     _.set(parameters, "auth.cookies", cookies);
+    _.set(parameters, "auth.type", "cookie");
   }
 
   return parameters;

--- a/test/unit/agent/authentication.js
+++ b/test/unit/agent/authentication.js
@@ -11,6 +11,39 @@ describe("lib/engine/agent/authentication", function () {
   afterEach(() => sandbox.restore());
 
   describe(".authenticate", () => {
+    it("authenticate with invalid type ", () => {
+      const agent = {
+        settings: {
+          auth: {
+            type: "bar",
+          },
+        },
+      };
+      return authentication.authenticate(agent, "ENDPOINT_URL").catch((err) => {
+        assert.ok(err.message.match(/Missing authenticator type/));
+      });
+    });
+    it("authenticate by type", () => {
+      const agent = {
+        settings: {
+          auth: {
+            type: "foo",
+          },
+        },
+      };
+      authentication.AUTHENTICATORS.foo = sinon
+        .stub()
+        .returns(Promise.resolve());
+      return authentication.authenticate(agent, "ENDPOINT_URL").then(() => {
+        assert.ok(
+          authentication.AUTHENTICATORS.foo.calledWithExactly(
+            agent.settings,
+            agent,
+            "ENDPOINT_URL"
+          )
+        );
+      });
+    });
     it("authenticate by cookie", () => {
       const agent = {
         settings: {

--- a/test/unit/agent/authentication.js
+++ b/test/unit/agent/authentication.js
@@ -44,26 +44,6 @@ describe("lib/engine/agent/authentication", function () {
         );
       });
     });
-    it("authenticate by cookie", () => {
-      const agent = {
-        settings: {
-          auth: {
-            cookies: ["COOKIE"],
-          },
-        },
-      };
-      sandbox
-        .stub(authentication, "authenticateByCookie")
-        .returns(Promise.resolve());
-      return authentication.authenticate(agent, "ENDPOINT_URL").then(() => {
-        assert.ok(
-          authentication.authenticateByCookie.calledWithExactly(
-            agent,
-            "ENDPOINT_URL"
-          )
-        );
-      });
-    });
     it("auto authentication", () => {
       const agent = {};
       sandbox

--- a/test/unit/agent/authentication/cookie.js
+++ b/test/unit/agent/authentication/cookie.js
@@ -1,0 +1,131 @@
+"use strict";
+
+const assert = require("assert").strict;
+const sinon = require("sinon");
+const authenticator = require("../../../../lib/agent/authentication/cookie", {});
+const sandbox = sinon.createSandbox();
+
+describe("lib/agent/authentification/cookie", function () {
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("authenticate", function () {
+    const agent = {
+      fetch: sinon.stub().returns(Promise.resolve("RESPONSE")),
+    };
+    sandbox.stub(authenticator, "setCookiesToAgent").returns(Promise.resolve());
+    sandbox
+      .stub(authenticator, "processResponse")
+      .returns(Promise.resolve("PROCESSED_RESPONSER"));
+
+    return authenticator("SETTINGS", agent, "ENDPOINT_URL").then((response) => {
+      assert.equal("PROCESSED_RESPONSER", response);
+      assert.ok(
+        authenticator.setCookiesToAgent.calledWithExactly(
+          "SETTINGS",
+          agent,
+          "ENDPOINT_URL"
+        )
+      );
+      assert.ok(authenticator.processResponse.calledWithExactly("RESPONSE"));
+    });
+  });
+
+  describe("setCookiesToAgent", () => {
+    let settings;
+    let agent;
+
+    beforeEach(() => {
+      settings = {
+        auth: {
+          cookies: ["COOKIE"],
+        },
+      };
+      agent = {
+        cookieJar: {
+          setCookie: sinon.stub(),
+        },
+      };
+    });
+
+    it("Invalid cookies in settings", () => {
+      settings.auth.cookies = "";
+      authenticator
+        .setCookiesToAgent(settings, "AGENT", "ENDPOINT_URL")
+        .catch((err) => {
+          assert.ok(err.match(/Invalid/));
+        });
+    });
+
+    it("set cookie to agent failes", () => {
+      const promise = authenticator.setCookiesToAgent(
+        settings,
+        agent,
+        "ENDPOINT_URL"
+      );
+
+      agent.cookieJar.setCookie.getCall(0).args[2]("ERROR");
+      assert.equal(agent.cookieJar.setCookie.getCall(0).args[0], "COOKIE");
+      assert.equal(
+        agent.cookieJar.setCookie.getCall(0).args[1],
+        "ENDPOINT_URL"
+      );
+
+      return promise.catch((err) => {
+        assert.equal(err, "ERROR");
+      });
+    });
+
+    it("set cookie to agent done successfully", () => {
+      const promise = authenticator.setCookiesToAgent(
+        settings,
+        agent,
+        "ENDPOINT_URL"
+      );
+
+      agent.cookieJar.setCookie.getCall(0).args[2](null, "SAVED_COOKIE");
+      assert.equal(agent.cookieJar.setCookie.getCall(0).args[0], "COOKIE");
+      assert.equal(
+        agent.cookieJar.setCookie.getCall(0).args[1],
+        "ENDPOINT_URL"
+      );
+
+      return promise.then((savedCookies) => {
+        assert.deepEqual(savedCookies, ["SAVED_COOKIE"]);
+      });
+    });
+  });
+
+  describe("processResponse", () => {
+    it("failed for error HTTP status", () => {
+      assert.throws(() => {
+        authenticator.processResponse({
+          status: 400,
+        });
+      }, /Service rejects/);
+    });
+
+    it("failed for invalid content type", () => {
+      assert.throws(() => {
+        authenticator.processResponse({
+          status: 200,
+          headers: {
+            get: sinon.stub().returns("application/json"),
+          },
+        });
+      }, /Invalid metadata/);
+    });
+
+    it("Successfully checked response", () => {
+      const response = {
+        status: 200,
+        headers: {
+          get: sinon.stub().returns("application/xml"),
+        },
+      };
+      assert.equal(authenticator.processResponse(response), response);
+      assert.ok(response.headers.get.calledWithExactly("content-type"));
+    });
+  });
+});

--- a/test/unit/agent/settings.js
+++ b/test/unit/agent/settings.js
@@ -264,6 +264,7 @@ describe("settings", function () {
       assert.deepEqual(parameters, {
         auth: {
           cookies: ["COOKIE"],
+          type: "cookie",
         },
       });
       assert.ok(
@@ -277,6 +278,7 @@ describe("settings", function () {
       assert.deepEqual(parameters, {
         auth: {
           cookies: ["ENV_COOKIE"],
+          type: "cookie",
         },
       });
       assert.ok(
@@ -290,6 +292,7 @@ describe("settings", function () {
       assert.deepEqual(parameters, {
         auth: {
           cookies: ["ENV_COOKIE", "ENV_COOKIE"],
+          type: "cookie",
         },
       });
       assert.ok(
@@ -302,6 +305,7 @@ describe("settings", function () {
       assert.deepEqual(parameters, {
         auth: {
           cookies: ["COOKIE"],
+          type: "cookie",
         },
       });
       assert.ok(


### PR DESCRIPTION
Add possibility to specify authentication type directly without automatically tries different types of authentication.

The patch solves #76 