### PR TITLE
[FIX] Emulate Fetch API response in batch processing

### DIFF
--- a/lib/agent/batch/Headers.js
+++ b/lib/agent/batch/Headers.js
@@ -1,0 +1,67 @@
+"use strict";
+
+const _ = require("lodash");
+
+/**
+ * Mimicry of Headers class from WebAPI for Batch responses
+ * keep current behavior by dynamic properties
+ *
+ * @public
+ *
+ * @class Headers
+ */
+class Headers {
+  /**
+   * Create instance of Headers
+   *
+   * @param {Array} rawHeaders array of batch response headers
+   *
+   * @constructor
+   */
+  constructor(rawHeaders) {
+    this.headerKeys = [];
+    this.parseHeadersArray(rawHeaders);
+  }
+
+  /**
+   * Convert rawHeaders array to instance properties
+   * and fill headerKeys map
+   *
+   * @param {Array} rawHeaders array of batch response headers
+   *
+   * @private
+   */
+  parseHeadersArray(rawHeaders) {
+    _.each(rawHeaders, (headerValue, index) => {
+      let headerKey;
+      if (index % 2) {
+        headerKey = rawHeaders[index - 1];
+        this[headerKey] = headerValue;
+        this.headerKeys.push(headerKey);
+      }
+    });
+  }
+
+  /**
+   * Returns content of the header by its name
+   * the headerName comparation is case-insensitive
+   *
+   * @param {String} headerName header name to find
+   *
+   * @returns {String} header content
+   *
+   * @public
+   */
+  get(headerName) {
+    const normalizedKey = _.find(
+      this.headerKeys,
+      (headerKey) =>
+        _.isString(headerName) &&
+        _.isString(headerKey) &&
+        headerName.toLowerCase() === headerKey.toLowerCase()
+    );
+    return this[normalizedKey];
+  }
+}
+
+module.exports = Headers;

--- a/lib/agent/batch/Response.js
+++ b/lib/agent/batch/Response.js
@@ -4,6 +4,7 @@ const EventEmitter = require("events");
 const _ = require("lodash");
 const HTTPParser = require("http-parser-js").HTTPParser;
 const parsers = require("../parsers");
+const Headers = require("./Headers");
 const responseType = require("../../engine/responseType");
 
 /**
@@ -254,18 +255,7 @@ class Response extends EventEmitter {
       this[headerInfoKey] = headerInfoValue;
     });
     this.rawHeaders = this.headers;
-    this.headers = _.reduce(
-      this.rawHeaders,
-      (headers, headerValue, index) => {
-        let headerKey;
-        if (index % 2) {
-          headerKey = this.rawHeaders[index - 1];
-          headers[headerKey] = headerValue;
-        }
-        return headers;
-      },
-      {}
-    );
+    this.headers = new Headers(this.rawHeaders);
   }
 
   /**
@@ -345,6 +335,15 @@ class Response extends EventEmitter {
         break;
     }
     return result || this;
+  }
+
+  /**
+   * It is mimicry for Fetch API Response json method
+   *
+   * @returns {Promise} promise resolved by body as json format
+   */
+  json() {
+    return Promise.resolve(this.body);
   }
 }
 

--- a/test/unit/agent/batch/Headers.js
+++ b/test/unit/agent/batch/Headers.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const assert = require("assert").strict;
+const _ = require("lodash");
+const Headers = require("../../../../lib/agent/batch/Headers");
+
+describe("agent/batch/Headers", function () {
+  let headers;
+
+  beforeEach(function () {
+    headers = new Headers([]);
+  });
+
+  it(".constructor", function () {
+    assert.deepEqual(headers.headerKeys, []);
+  });
+
+  describe(".parseHeadersArray", function () {
+    it("valid headers passed", function () {
+      headers.parseHeadersArray([
+        "header1",
+        "HEADER_1_VALUE",
+        "header2",
+        "HEADER_2_VALUE",
+      ]);
+      assert.equal(headers.header1, "HEADER_1_VALUE");
+      assert.equal(headers.header2, "HEADER_2_VALUE");
+      assert.deepEqual(headers.headerKeys, ["header1", "header2"]);
+    });
+    it("odd raw headers array", function () {
+      headers.parseHeadersArray(["header1", "HEADER_1_VALUE", "header2"]);
+      assert.equal(headers.header1, "HEADER_1_VALUE");
+      assert.ok(!_.has(headers, "header2"));
+      assert.deepEqual(headers.headerKeys, ["header1"]);
+    });
+  });
+
+  it("odd raw headers array", function () {
+    headers.headerKeys = ["Content-Type"];
+    headers["Content-Type"] = "CONTENT_TYPE";
+    assert.equal(headers.get("Content-Type"), "CONTENT_TYPE");
+    assert.equal(headers.get("content-type"), "CONTENT_TYPE");
+    assert.equal(headers.get("content-Type"), "CONTENT_TYPE");
+    assert.equal(headers.get("missing-header"), undefined);
+  });
+});


### PR DESCRIPTION
Function import implementation follows Fetch API
after new Fetch API usage, but Batch processing
does not emulate the Fetch APi. Patch implements
Response.json method and Headers class.

Topic: #77