### PR TITLE
[FEATURE] Add authentication by client certificate

### DIFF
--- a/lib/agent/Agent.js
+++ b/lib/agent/Agent.js
@@ -8,6 +8,7 @@ const xml2js = require("xml2js");
 const nodeFetch = require("node-fetch");
 const tough = require("tough-cookie");
 const authentication = require("./authentication");
+const https = require("https");
 
 const AUTH_HEADERS = Symbol("AUTH_HEADERS");
 const CSRF_TOKEN = Symbol("CSRF_TOKEN");
@@ -54,6 +55,30 @@ class Agent {
       value: new tough.CookieJar(),
       writable: false,
     });
+    Object.defineProperty(this, "defaultFetchOptions", {
+      value: this.initializeDefaultFetchOptions(settings),
+      writable: false,
+    });
+  }
+
+  /**
+   * Initialize object merged with user definined options
+   * for fetch and passed as options to the node-fetch
+   *
+   * @param {Object} settings define service endpoint
+   *
+   * @returns {Object} initialized options
+   */
+  initializeDefaultFetchOptions(settings) {
+    const AGENT_OPTIONS = ["cert", "key", "pfx", "ca", "passphrase"];
+    const defaultAgentOptions = _.pick(_.get(settings, "auth"), AGENT_OPTIONS);
+    const defaultFetchOptions = {};
+
+    if (_.keys(defaultAgentOptions).length > 0) {
+      defaultFetchOptions.agent = new https.Agent(defaultAgentOptions);
+    }
+
+    return defaultFetchOptions;
   }
 
   /**
@@ -497,6 +522,7 @@ class Agent {
    * @returns {Promise} promise which is resolved when HTTP request is done
    */
   fetch(requestUrl, opts = {}) {
+    let normalizedOpts;
     let isRequestedManualRedirect;
     let follow;
     let response;
@@ -505,17 +531,27 @@ class Agent {
     if (!_.isObject(opts)) {
       throw new Error("Invalid options passed for HTTP request.");
     }
+
+    normalizedOpts = _.assign({}, this.defaultFetchOptions, opts);
     counter = requestCounter++;
 
-    isRequestedManualRedirect = opts.redirect === "manual";
-    follow = opts.follow;
+    isRequestedManualRedirect = normalizedOpts.redirect === "manual";
+    follow = normalizedOpts.follow;
 
     return this.readCookies(requestUrl)
       .then((cookies) => {
-        this.appendHeaders({ Cookie: cookies }, opts);
-        this.appendHeaders(this[AUTH_HEADERS], opts);
-        log.logRequest(this.logger, counter, requestUrl, opts);
-        return nodeFetch(requestUrl, _.assign({ redirect: "manual" }, opts));
+        this.appendHeaders({ Cookie: cookies }, normalizedOpts);
+        this.appendHeaders(this[AUTH_HEADERS], normalizedOpts);
+        log.logRequest(
+          this.logger,
+          counter,
+          requestUrl,
+          _.pickBy(normalizedOpts, (value, key) => key !== "agent")
+        );
+        return nodeFetch(
+          requestUrl,
+          _.assign({ redirect: "manual" }, normalizedOpts)
+        );
       })
       .then((res) => {
         response = res;
@@ -528,8 +564,8 @@ class Agent {
           follow,
           isRequestedManualRedirect
         )
-          ? this.redirect(counter, requestUrl, opts, response)
-          : this.processResponse(counter, requestUrl, opts, response);
+          ? this.redirect(counter, requestUrl, normalizedOpts, response)
+          : this.processResponse(counter, requestUrl, normalizedOpts, response);
       });
   }
 

--- a/lib/agent/authentication.js
+++ b/lib/agent/authentication.js
@@ -7,6 +7,7 @@ exports.AUTHENTICATORS = {
   none: require("./authentication/none"),
   samlSap: require("./authentication/samlSap"),
   cookie: require("./authentication/cookie"),
+  cert: require("./authentication/cert"),
 };
 
 exports.AUTHENTICATORS_AUTO_ORDER = [

--- a/lib/agent/authentication/cert.js
+++ b/lib/agent/authentication/cert.js
@@ -1,0 +1,34 @@
+"use strict";
+
+const authBasic = require("./basic");
+
+/**
+ * Try to load service endpoint with basic authentication
+ *
+ * @param {Object} settings - normalized OData library settings. contains
+ *        user creadentials
+ * @param {Agent} agent - instance of superagent HTTP client
+ * @param {String} endpointUrl - url which is used for testing
+ *
+ * @return {Promise} the promise is resolved when endpoint is correctly loaded,
+ *                       the promise is rejected othewise
+ */
+function authenticate(settings, agent, endpointUrl) {
+  return new Promise((resolve, reject) => {
+    agent
+      .fetch(endpointUrl)
+      .then((res) => {
+        if (authBasic.isValidResponse(res)) {
+          resolve(res);
+        } else {
+          let err = new Error("Client certification authentification failed.");
+          reject(err);
+        }
+      })
+      .catch(reject);
+  });
+}
+
+authenticate.authenticatorName = "Certificate";
+
+module.exports = authenticate;

--- a/lib/agent/settings.js
+++ b/lib/agent/settings.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const _ = require("lodash");
-const fs = require("fs");
 const url = require("./url");
 
 /**
@@ -144,30 +143,6 @@ function parseConnectionObject(connectionSettings, parameters) {
 }
 
 /**
- * Try to get certificate used for connection to the odata service
- *
- * @param {Object} connectionSettings - string which could contains corrently defined url
- * @param {Object} parameters - reference to parameter structure which is updated by method
- *
- * @return {Object} returns structure defining OData endpoint
- */
-function parseCa(connectionSettings, parameters) {
-  var caCertPath;
-
-  if (_.isString(connectionSettings.caCertPath)) {
-    caCertPath = connectionSettings.caCertPath;
-  } else if (_.isString(process.env.ODATA_CA_CERT_PATH)) {
-    caCertPath = process.env.ODATA_CA_CERT_PATH;
-  }
-
-  if (caCertPath) {
-    parameters.ca = fs.readFileSync(caCertPath);
-  }
-
-  return parameters;
-}
-
-/**
  * Parse connection settings passed to the client object
  *
  * @param {String|Object} connectionSettings - url or object with url and auth settings
@@ -197,9 +172,15 @@ function parseSettings(connectionSettings = process.env.ODATA_URL) {
     throw new Error("Invalid OData service connection settings");
   }
 
-  parameters = parseCa(connectionSettings, parameters);
   parameters = parseSettings._.parseConnectionCookie(
     connectionSettings,
+    parameters
+  );
+
+  parameters = parseSettings._.parseTLSDefinitions(
+    parseSettings.AUTH.CERT,
+    connectionSettings,
+    process.env,
     parameters
   );
 
@@ -223,7 +204,7 @@ parseSettings._.parseConnectionCookie = function parseConnectionCookie(
   let cookies;
 
   if (!parseSettings._.checkCookieSettings(connectionSettings)) {
-    throw new Error("Invalid cookie definition");
+    throw new Error("Invalid authenticate cookie settings");
   }
 
   if (_.has(connectionSettings, "auth.cookies")) {
@@ -242,6 +223,13 @@ parseSettings._.parseConnectionCookie = function parseConnectionCookie(
   return parameters;
 };
 
+/**
+ * Check if cookie settings is correct
+ *
+ * @param {Object} connectionSettings - object which could contains corrently defined url
+ *
+ * @return {Object} returns structure defining OData endpoint
+ */
 parseSettings._.checkCookieSettings = function (connectionSettings) {
   let check = true;
 
@@ -259,6 +247,170 @@ parseSettings._.checkCookieSettings = function (connectionSettings) {
   }
 
   return check;
+};
+
+parseSettings.AUTH = {
+  CERT: {
+    PEM_OBJECT_KEYS: {
+      ORDER: 1,
+      SOURCE: "SETTINGS",
+      MANDATORY_KEYS: ["auth.cert", "auth.key"],
+      OPTIONAL_KEYS: ["auth.ca"],
+      ADDITIONAL_KEYS: {
+        "auth.type": "cert",
+      },
+    },
+    PFX_OBJECT_KEYS: {
+      ORDER: 2,
+      SOURCE: "SETTINGS",
+      MANDATORY_KEYS: ["auth.pfx", "auth.passphrase"],
+      OPTIONAL_KEYS: ["auth.ca"],
+      ADDITIONAL_KEYS: {
+        "auth.type": "cert",
+      },
+    },
+    PEM_ENVIRONMENT_KEYS: {
+      ORDER: 3,
+      SOURCE: "ENV",
+      MANDATORY_KEYS: ["ODATA_CLIENT_CERT", "ODATA_CLIENT_KEY"],
+      OPTIONAL_KEYS: ["ODATA_EXTRA_CA"],
+      CONVERSION: {
+        ODATA_CLIENT_CERT: "auth.cert",
+        ODATA_CLIENT_KEY: "auth.key",
+        ODATA_EXTRA_CA: "auth.ca",
+      },
+      ADDITIONAL_KEYS: {
+        "auth.type": "cert",
+      },
+    },
+    CA_OBJECT_KEYS: {
+      ORDER: 4,
+      SOURCE: "SETTINGS",
+      MANDATORY_KEYS: ["auth.ca"],
+      OPTIONAL_KEYS: [],
+    },
+    CA_ENVIRONMENT_KEYS: {
+      ORDER: 5,
+      SOURCE: "ENV",
+      MANDATORY_KEYS: ["ODATA_EXTRA_CA"],
+      OPTIONAL_KEYS: [],
+      CONVERSION: { ODATA_EXTRA_CA: "auth.ca" },
+    },
+  },
+};
+
+/**
+ * Determine type of template from AUTH.CERT for
+ * checking and parsing TLS definitions
+ *
+ * @param {Array} templateDefinitions - list of templates for TLS definitionis (coming from AUTH.CERT)
+ * @param {Object} connectionSettings - object which could contains corrently defined url
+ * @param {Object} processEnv - map of environment variables
+ *
+ * @return {Object} template TLS settings
+ */
+parseSettings._.determineTLSDefinition = function (
+  templateDefinitions,
+  connectionSettings,
+  processEnv
+) {
+  return _.map(templateDefinitions, (def, key) =>
+    _.assign(
+      {
+        key: key,
+        source: def.SOURCE === "ENV" ? processEnv : connectionSettings,
+      },
+      def
+    )
+  )
+    .sort((defA, defB) => defA.ORDER - defB.ORDER)
+    .find((def) => def.MANDATORY_KEYS.some((key) => _.has(def.source, key)));
+};
+
+/**
+ * Check current TLS settings by template
+ *
+ * @param {Array} templateDefinition - list of templates for TLS definitionis (coming from AUTH.CERT)
+ * @param {Object} connectionSettings - object which could contains corrently defined url
+ * @param {Object} processEnv - map of environment variables
+ * @param {Object} parameters - parsed settings
+ *
+ * @return {Error} error description
+ */
+parseSettings._.checkTLSDefinition = function (
+  definition,
+  connectionSettings,
+  processEnv,
+  parameters
+) {
+  let error;
+
+  if (definition) {
+    if (!(_.get(parameters, "url") || "").match(/^https/)) {
+      error = new Error("Use SSL parameters with HTTPS only.");
+    } else {
+      const missingKeys = definition.MANDATORY_KEYS.filter(
+        (mandatoryKey) => !_.has(definition.source, mandatoryKey)
+      );
+      if (missingKeys.length > 0) {
+        error = new Error(`Missing certificate parameter ${missingKeys[0]}.`);
+      }
+    }
+  }
+
+  return error;
+};
+
+/**
+ * Parse TLS settings
+ *
+ * @param {Array} templateDefinitions - list of templates for TLS definitionis (coming from AUTH.CERT)
+ * @param {Object} connectionSettings - object which could contains corrently defined url
+ * @param {Object} processEnv - map of environment variables
+ * @param {Object} parameters - parsed settings
+ *
+ * @return {Object} parameters with TLS settings
+ */
+parseSettings._.parseTLSDefinitions = function (
+  templateDefinitions,
+  connectionSettings,
+  processEnv,
+  parameters
+) {
+  const definition = parseSettings._.determineTLSDefinition(
+    templateDefinitions,
+    connectionSettings,
+    processEnv
+  );
+
+  const err = parseSettings._.checkTLSDefinition(
+    definition,
+    connectionSettings,
+    processEnv,
+    parameters
+  );
+
+  if (err) {
+    throw err;
+  } else if (definition) {
+    _.concat([], definition.MANDATORY_KEYS, definition.OPTIONAL_KEYS)
+      .filter((path) => _.has(definition.source, path))
+      .forEach((sourcePath) => {
+        const destinationPath = _.has(definition, "CONVERSION." + sourcePath)
+          ? definition.CONVERSION[sourcePath]
+          : sourcePath;
+        _.set(
+          parameters,
+          destinationPath,
+          _.get(definition.source, sourcePath)
+        );
+      });
+    _.each(definition.ADDITIONAL_KEYS, (value, path) =>
+      _.set(parameters, path, value)
+    );
+  }
+
+  return parameters;
 };
 
 module.exports = parseSettings;

--- a/test/unit/agent/Agent.js
+++ b/test/unit/agent/Agent.js
@@ -9,6 +9,7 @@ const xml2js = require("xml2js");
 const tough = require("tough-cookie");
 const log = require("../../../lib/agent/log");
 const authentication = require("../../../lib/agent/authentication");
+const https = require("https");
 
 let Agent;
 let agent;
@@ -39,6 +40,37 @@ describe("lib/engine/Agent", function () {
         url: "URL",
       });
       assert.ok(_.has(agent, "logger"));
+      assert.deepEqual(agent.defaultFetchOptions, {});
+    });
+  });
+
+  describe("initializeDefaultFetchOptions", function () {
+    it("settings for default fetch options not found", function () {
+      assert.deepEqual(agent.initializeDefaultFetchOptions({ url: "URL" }), {});
+    });
+    it("settings for default fetch options not found", function () {
+      sandbox.stub(https, "Agent");
+      const defaultOptions = agent.initializeDefaultFetchOptions({
+        url: "URL",
+        auth: {
+          cert: "CERT",
+          key: "KEY",
+          pfx: "PFX",
+          ca: "CA",
+          passphrase: "PASSPHRASE",
+          foo: "BAR",
+        },
+      });
+      assert.ok(defaultOptions.agent instanceof https.Agent);
+      assert.ok(
+        https.Agent.calledWithExactly({
+          cert: "CERT",
+          key: "KEY",
+          pfx: "PFX",
+          ca: "CA",
+          passphrase: "PASSPHRASE",
+        })
+      );
     });
   });
 
@@ -655,6 +687,7 @@ describe("lib/engine/Agent", function () {
       sinon.stub(agent, "processResponse").returns(Promise.resolve());
       opts = {};
       agent.setAuthorizationHeaders({ "x-csrf-token": "X-CSRF-TOKEN" });
+      agent.defaultFetchOptions.defaultOption = "DEFAULT_OPTION";
     });
     it("invalid options", function () {
       assert.throws(function () {
@@ -669,22 +702,33 @@ describe("lib/engine/Agent", function () {
             {
               Cookie: "COOKIES",
             },
-            opts
+            {
+              defaultOption: "DEFAULT_OPTION",
+            }
           )
         );
         assert.ok(
           agent.appendHeaders.calledWithExactly(
             { "x-csrf-token": "X-CSRF-TOKEN" },
-            opts
+            {
+              defaultOption: "DEFAULT_OPTION",
+            }
           )
         );
         assert.equal(log.logRequest.getCall(0).args[0], agent.logger);
         assert.ok(_.isNumber(log.logRequest.getCall(0).args[1]));
         assert.deepEqual(log.logRequest.getCall(0).args.slice(2), [
           "URL",
-          opts,
+          {
+            defaultOption: "DEFAULT_OPTION",
+          },
         ]);
-        assert.ok(nodeFetch.calledWithExactly("URL", { redirect: "manual" }));
+        assert.ok(
+          nodeFetch.calledWithExactly("URL", {
+            redirect: "manual",
+            defaultOption: "DEFAULT_OPTION",
+          })
+        );
         assert.ok(agent.saveCookies.calledWithExactly("RESPONSE"));
         assert.ok(
           agent.isResponseRedirect.calledWithExactly(
@@ -697,7 +741,9 @@ describe("lib/engine/Agent", function () {
         assert.ok(_.isNumber(agent.processResponse.getCall(0).args[0]));
         assert.deepEqual(agent.processResponse.getCall(0).args.slice(1), [
           "URL",
-          opts,
+          {
+            defaultOption: "DEFAULT_OPTION",
+          },
           "RESPONSE",
         ]);
       });
@@ -711,22 +757,33 @@ describe("lib/engine/Agent", function () {
             {
               Cookie: "COOKIES",
             },
-            opts
+            {
+              defaultOption: "DEFAULT_OPTION",
+            }
           )
         );
         assert.ok(
           agent.appendHeaders.calledWithExactly(
             { "x-csrf-token": "X-CSRF-TOKEN" },
-            opts
+            {
+              defaultOption: "DEFAULT_OPTION",
+            }
           )
         );
         assert.equal(log.logRequest.getCall(0).args[0], agent.logger);
         assert.ok(_.isNumber(log.logRequest.getCall(0).args[1]));
         assert.deepEqual(log.logRequest.getCall(0).args.slice(2), [
           "URL",
-          opts,
+          {
+            defaultOption: "DEFAULT_OPTION",
+          },
         ]);
-        assert.ok(nodeFetch.calledWithExactly("URL", { redirect: "manual" }));
+        assert.ok(
+          nodeFetch.calledWithExactly("URL", {
+            redirect: "manual",
+            defaultOption: "DEFAULT_OPTION",
+          })
+        );
         assert.ok(agent.saveCookies.calledWithExactly("RESPONSE"));
         assert.ok(
           agent.isResponseRedirect.calledWithExactly(
@@ -739,7 +796,9 @@ describe("lib/engine/Agent", function () {
         assert.ok(_.isNumber(agent.redirect.getCall(0).args[0]));
         assert.deepEqual(agent.redirect.getCall(0).args.slice(1), [
           "URL",
-          opts,
+          {
+            defaultOption: "DEFAULT_OPTION",
+          },
           "RESPONSE",
         ]);
       });

--- a/test/unit/agent/authentication/cert.js
+++ b/test/unit/agent/authentication/cert.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const assert = require("assert").strict;
+const sinon = require("sinon");
+const _ = require("lodash");
+const sandbox = sinon.createSandbox();
+const authenticator = require("../../../../lib/agent/authentication/cert");
+const authBasic = require("../../../../lib/agent/authentication/basic");
+
+describe("lib/agent/authentification/cert", function () {
+  let agent;
+  let settings;
+
+  beforeEach(function () {
+    agent = {
+      fetch: sinon.stub(),
+    };
+    settings = {};
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it("Identification is set", function () {
+    assert.ok(_.isString(authenticator.authenticatorName));
+  });
+
+  it("Request to endpoint is correctly loaded", function () {
+    sandbox.stub(authBasic, "isValidResponse").returns(true);
+    agent.fetch.returns(Promise.resolve("VALID_RESPONSE"));
+    return authenticator(settings, agent, "ENDPOINT_URL").then(() => {
+      assert.ok(authBasic.isValidResponse.calledWith("VALID_RESPONSE"));
+      assert.ok(agent.fetch.calledWithExactly("ENDPOINT_URL"));
+    });
+  });
+
+  it("Request endpoint fails with basic authorization ", function () {
+    agent.fetch.returns(Promise.reject("ERROR"));
+    return authenticator(settings, agent, "ENDPOINT_URL").catch((err) => {
+      assert.equal(err, "ERROR");
+      assert.ok(!err.unsupported);
+      assert.ok(agent.fetch.calledWithExactly("ENDPOINT_URL"));
+    });
+  });
+});


### PR DESCRIPTION
The patch implement authentication via client ceriticates in PEM and PFX format. New parameters ca, cert, key, pfx and passphrase added to initialization. The client certificat authentication is not part of "automatic" determination of authentication type.

Topic: #81