### PR TITLE
Add If-Match header to MERGE request

### DIFF
--- a/lib/engine/QueryableResource.js
+++ b/lib/engine/QueryableResource.js
@@ -247,6 +247,7 @@ class QueryableResource extends Resource {
     return defaultBatch
       ? this._handleBatchCall(() => {
           this.defaultRequest.header("Accept", "application/json");
+          this.defaultRequest.header("If-Match", "*");
           return defaultBatch[methodName](
             path,
             this.defaultRequest._headers,
@@ -256,6 +257,7 @@ class QueryableResource extends Resource {
         }, defaultBatch)
       : this._handleAgentCall((request) => {
           request.header("Content-Type", "application/json");
+          request.header("If-Match", "*");
           return this.agent[methodName](
             path,
             request._headers,

--- a/test/unit/engine/QueryableResource.js
+++ b/test/unit/engine/QueryableResource.js
@@ -503,6 +503,9 @@ describe("QueryableResource", function () {
         })
         .then(() => {
           assert(request.header.calledWith("Content-Type", "application/json"));
+          assert.ok(
+            request.header.calledWithExactly("If-Match", "*")
+          );
           assert.deepEqual(innerAgent.merge.getCall(0).args, [
             "/ENTITY_SET_NAME(keyParameter='keyValue')",
             request._headers,
@@ -530,6 +533,9 @@ describe("QueryableResource", function () {
         .then(() => {
           assert.ok(request.payload.calledWithExactly("BODY_PROPERTIES"));
           assert(request.header.calledWith("Content-Type", "application/json"));
+          assert.ok(
+            request.header.calledWithExactly("If-Match", "*")
+          );
           assert.deepEqual(innerAgent.merge.getCall(0).args, [
             "/ENTITY_SET_NAME(keyParameter='keyValue')",
             request._headers,
@@ -556,6 +562,9 @@ describe("QueryableResource", function () {
         .then(() => {
           assert.ok(
             request.header.calledWith("Content-Type", "application/json")
+          );
+          assert.ok(
+            request.header.calledWithExactly("If-Match", "*")
           );
           assert.ok(entitySet._handleAgentCall.getCall(0).args[0](request));
           assert.deepEqual(innerAgent.merge.getCall(0).args, [
@@ -606,6 +615,9 @@ describe("QueryableResource", function () {
           assert.ok(
             request.header.calledWithExactly("Content-Type", "application/json")
           );
+          assert.ok(
+            request.header.calledWithExactly("If-Match", "*")
+          );
           assert.deepEqual(innerAgent.merge.getCall(0).args, [
             "/ENTITY_SET_NAME(keyParameter='keyValue')",
             request._headers,
@@ -646,6 +658,7 @@ describe("QueryableResource", function () {
         )
       );
       assert.ok(request.header.calledWithExactly("Accept", "application/json"));
+      assert.ok(request.header.calledWithExactly("If-Match", "*"));
       assert.ok(request.payload.calledWithExactly("BODY_PROPERTIES"));
       assert.ok(entitySet.bodyProperties.calledWithExactly(newData));
       assert.strictEqual(


### PR DESCRIPTION
In case that service is using eTag it is necessary to have If-Match header otherwise MERGE requests throws an error